### PR TITLE
Styles NumericStepper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Styles for NumericStepper component
 
 ## [0.2.4] - 2018-10-25
 

--- a/react/global.css
+++ b/react/global.css
@@ -64,11 +64,18 @@ div.vtex-modal__overlay {
 
 /* Quantity selector */
 .multiple-choice__actions input {
+  border-width: 0;
   width: 2.5rem;
 }
 .multiple-choice__actions button {
-  width: 1.75rem !important; /* inline styles so important is needed */
+  border-width: 0;
+  font-size: 1.25rem;
+  width: 2rem !important; /* inline styles so important is needed */
 }
+.multiple-choice__actions button[disabled] {
+  visibility: hidden;
+}
+
 .multiple-choice__price .vtex-price-selling {
   padding: 0;
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add styles for the NumericStepper component

#### What problem is this solving?
Following provided prototype for the default `delivery-dreamstore`.
Fixes the default size of NumericStepper being too big for mobile

#### How should this be manually tested?
[Visit workspace](https://stylestepperpr--delivery.myvtex.com/pizza-pepperoni/p).
Addendum: The green buttons is the store custom theme being used on that account, it just changes font-family and colours, nothing else that is inherited by NumericStepper

#### Screenshots or example usage
default style:
![numeric-stepper-defaults](https://user-images.githubusercontent.com/27775611/47520675-2e9be580-d867-11e8-9b64-fd20f6475fd3.png)

custom style:
![numeric-stepper-styled](https://user-images.githubusercontent.com/27775611/47520600-fd231a00-d866-11e8-873a-33375ad51669.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.