### PR TITLE
Remove ingredient customization modal and add inline component after SKU selection

### DIFF
--- a/react/components/IngredientsContent.js
+++ b/react/components/IngredientsContent.js
@@ -40,21 +40,11 @@ class IngredientsContent extends Component {
     if (!currentVariation) return null
 
     return (
-      <div className="vtex-product-customizer__change-ingredients pb5">
+      <div className="vtex-product-customizer__change-ingredients bg-white">
         <h3 className="b--light-gray bb bw1 pa5 ma0 b near-black">
           <FormattedMessage id="product-customizer.change-ingredients" />
         </h3>
         <div className="change-ingredients--selected-variation">
-          <legend className="bg-near-white w-100 ph2 pv4">
-            <FormattedMessage id="product-customizer.your-variation" />
-          </legend>
-          <div className="flex items-center pa2">
-            <img src={currentVariation.variation.image} width="48" className="br3 h-100" />
-            <div className="pa2">
-              <h4 className="ma0">{currentVariation.variation.name}</h4>
-            </div>
-          </div>
-
           <legend className="bg-near-white w-100 ph2 pv4 mb4">
             <FormattedMessage id="product-customizer.select-your-ingredients" />
           </legend>

--- a/react/components/ProductCustomizer.js
+++ b/react/components/ProductCustomizer.js
@@ -177,10 +177,12 @@ class ProductCustomizer extends Component {
    */
   handleVariationChange = async variationObject => {
     const { productQuery: { product } } = this.props
-    const sku = product.items.find(sku => sku.itemId === variationObject.skuId)
+    const variationSku = variation && variationObject.skuId
+    const sku = product.items.find(sku => sku.itemId === variationSku)
 
-    const optionalVariations = this.parseAttachments('optionals', sku)
-    const compositionVariations = this.parseAttachments('composition', sku)
+    // TODO: add proper error message to handle null variationObject and sku
+    const optionalVariations = sku ? this.parseAttachments('optionals', sku) : {variations : []}
+    const compositionVariations = sku ? this.parseAttachments('composition', sku) : {variations : []}
 
     const chosenAmountBasic = this.createBooleanIndexesStates(compositionVariations.variations)
     const chosenAmount = this.createNumericStepperIndexesStates(optionalVariations.variations)


### PR DESCRIPTION
Removed the ingredient customization modal and added it below the SKU selection component.
It should look like this:

![screen shot 2018-11-01 at 16 33 57](https://user-images.githubusercontent.com/7853668/47875139-881a8c00-ddf4-11e8-988f-63bb4594e6c7.png)
![screen shot 2018-11-01 at 16 34 37](https://user-images.githubusercontent.com/7853668/47875140-88b32280-ddf4-11e8-8606-d776b9f3e7ff.png)

Had to refactor the state logic to set all needed state at once, since at the moment that the SKU is selected the ingredient customization component should be rendered. 

There were several functions setting partial states which were required for the component to be rendered. I've aggregated all those functions in `handleVariationChange` and made other functions (like `createNumericStepperIndexesStates`) pure.

Also removed the `total` state, since it can be computed from other states.