### PR TITLE
Fix image size on ingredients choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.2.6] - 2018-11-06
+
 ## [0.2.5] - 2018-11-06
 
 ## [0.2.4] - 2018-10-25

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-customizer",
   "vendor": "vtex",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "title": "Product Customizer",
   "description": "",
   "mustUpdateAt": "2019-09-27",

--- a/react/components/Variation/Items/MultipleChoice.js
+++ b/react/components/Variation/Items/MultipleChoice.js
@@ -51,7 +51,9 @@ class MultipleChoice extends Component {
     return (
       <div className="vtex-product-customizer__multiple-choice w-100 flex justify-between items-center">
         <div className="flex align-center">
-          <img src={item.image} width="48" className="br3 h-100" />
+          <div>
+            <img src={item.image} width="48" className="br3" />
+          </div>
           <div className="multiple-choice__title flex flex-column justify-center pl2">
             <div className="multiple-choice__name">{item.name}</div>
             <div className="multiple-choice__price">

--- a/react/components/Variation/Items/ToggledChoice.js
+++ b/react/components/Variation/Items/ToggledChoice.js
@@ -44,7 +44,9 @@ class ToggledChoice extends Component {
     return (
       <label className="flex justify-between items-center pv4 bb b--light-gray pointer">
         <div className="flex items-center">
-          <img src={item.image} width="32" className="br3 h-100" />
+          <div>
+            <img src={item.image} width="32" className="br3" />
+          </div>
           <div className="pa5">
             <h4 className="ma0">{item.name}</h4>
           </div>


### PR DESCRIPTION
As the title says.

Works together with https://github.com/vtex/pizzahut/pull/2

Before:
<img width="436" alt="screen shot 2018-11-06 at 17 30 49" src="https://user-images.githubusercontent.com/5691711/48088783-022e8480-e1ea-11e8-9d69-72e0be3660b9.png">

After:
<img width="439" alt="screen shot 2018-11-06 at 17 27 25" src="https://user-images.githubusercontent.com/5691711/48088819-12defa80-e1ea-11e8-8938-f50806f45af9.png">

