### PR TITLE
Fix spinner alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Adjust the auto-scroll-to-ingredients function to scroll right to the header of the Ingredients section
+- Fix spinner alignment to match the one that comes from the parent component
 
 ## [0.2.6] - 2018-11-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.2.7] - 2018-11-07
+
 ### Changed
 
 - Use the lean mode of the NumericStepper component on MultipleChoice

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-customizer",
   "vendor": "vtex",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "title": "Product Customizer",
   "description": "",
   "mustUpdateAt": "2019-09-27",

--- a/react/ProductCustomizer.js
+++ b/react/ProductCustomizer.js
@@ -9,7 +9,11 @@ class ProductCustomizerIndex extends Component {
   render() {
     const { productQuery: { loading, product } } = this.props
 
-    if (loading) return <Spinner />
+    if (loading) return (
+      <div className="flex justify-center pa8 w-100">
+        <Spinner />
+      </div>
+    )
 
     const hasSchema = head(product.items).calculatedAttachments
 


### PR DESCRIPTION
As the title says.

Previously the spinner was being aligned to the left of the screen at a certain point of the loading process. This was being caused when the spinner displayed was the one from this component, but it did not have the same alignment as the one that comes by default.