### PR TITLE
Fix/ingredients scroll mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.2.10] - 2018-11-07
+
 ### Fixed
 
 - Fixes ingredients auto-scroll positioning on mobile--previously it was missing the mark by a few pixels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixes ingredients auto-scroll positioning on mobile--previously it was missing the mark by a few pixels.
+
 ## [0.2.9] - 2018-11-07
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "product-customizer",
   "vendor": "vtex",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "title": "Product Customizer",
   "description": "",
   "mustUpdateAt": "2019-09-27",

--- a/react/components/ProductCustomizer.js
+++ b/react/components/ProductCustomizer.js
@@ -214,7 +214,7 @@ class ProductCustomizer extends Component {
 
   scrollToIngredients = () => {
     // TODO: find a better way for getting the top menu element
-    const topbar = document && document.querySelector('.vtex-top-menu') 
+    const topbar = document && document.querySelector('.vtex-top-menu-fixed') 
     const topbarHeight = topbar ? topbar.scrollHeight : 0
     this.ingredientsContentAnchor.current.style.top = `${(-topbarHeight)}px`
     this.scrollIntoView(this.ingredientsContentAnchor.current)


### PR DESCRIPTION
Fixes bug where the ingredients auto-scroll was using the expanded menu for calculation of the scroll position, instead of the collapsed version.

Works in tandem with https://github.com/vtex-apps/dreamstore-header/pull/16