### PR TITLE
Handle required field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Handle require field.
 
 ## [2.3.0] - 2019-09-16
 ### Added

--- a/react/__mocks__/productAttachment.json
+++ b/react/__mocks__/productAttachment.json
@@ -1281,7 +1281,7 @@
               {
                 "id": "Customization",
                 "name": "Customization",
-                "required": false,
+                "required": true,
                 "inputValues": [
                   {
                     "label": "Font",

--- a/react/__mocks__/productAttachment.json
+++ b/react/__mocks__/productAttachment.json
@@ -1183,6 +1183,7 @@
               {
                 "id": "Customization",
                 "name": "Customization",
+                "required": false,
                 "inputValues": [
                   {
                     "label": "Font",
@@ -1231,6 +1232,7 @@
               {
                 "id": "Customization",
                 "name": "Customization",
+                "required": false,
                 "inputValues": [
                   {
                     "label": "Font",
@@ -1279,6 +1281,7 @@
               {
                 "id": "Customization",
                 "name": "Customization",
+                "required": false,
                 "inputValues": [
                   {
                     "label": "Font",

--- a/react/__mocks__/productCustomBell.json
+++ b/react/__mocks__/productCustomBell.json
@@ -504,6 +504,7 @@
               {
                 "id": "add-on_Add-on",
                 "name": "add-on",
+                "required": false,
                 "inputValues": [],
                 "composition": {
                   "minQuantity": 0,
@@ -544,6 +545,7 @@
               {
                 "id": "text_style_Text Style",
                 "name": "text_style",
+                "required": false,
                 "inputValues": [],
                 "composition": {
                   "minQuantity": 1,
@@ -575,6 +577,7 @@
               {
                 "id": "engraving_Engraving",
                 "name": "engraving",
+                "required": false,
                 "inputValues": [],
                 "composition": {
                   "minQuantity": 0,
@@ -655,6 +658,7 @@
               {
                 "id": "1-3-lines",
                 "name": "1-3-lines",
+                "required": false,
                 "inputValues": [
                   {
                     "label": "Line 1",
@@ -693,6 +697,7 @@
               {
                 "id": "4-lines",
                 "name": "4-lines",
+                "required": false,
                 "inputValues": [
                   {
                     "label": "Line 1",
@@ -738,6 +743,7 @@
               {
                 "id": "add-on_Add-on",
                 "name": "add-on",
+                "required": false,
                 "inputValues": [],
                 "composition": {
                   "minQuantity": 0,
@@ -778,6 +784,7 @@
               {
                 "id": "text_style_Text Style",
                 "name": "text_style",
+                "required": false,
                 "inputValues": [],
                 "composition": {
                   "minQuantity": 1,
@@ -809,6 +816,7 @@
               {
                 "id": "engraving_Engraving",
                 "name": "engraving",
+                "required": false,
                 "inputValues": [],
                 "composition": {
                   "minQuantity": 0,

--- a/react/__mocks__/productPizza.json
+++ b/react/__mocks__/productPizza.json
@@ -180,6 +180,7 @@
               {
                 "id": "pizza_composition_Pizza flavor",
                 "name": "pizza_composition",
+                "required": false,
                 "inputValues": [],
                 "composition": {
                   "minQuantity": 1,
@@ -202,6 +203,7 @@
               {
                 "id": "drinks_size_double_Choose 2 drinks",
                 "name": "drinks_size_double",
+                "required": false,
                 "inputValues": [],
                 "composition": {
                   "minQuantity": 2,
@@ -251,6 +253,7 @@
               {
                 "id": "pizza_extra_ingredients_Extra",
                 "name": "pizza_extra_ingredients",
+                "required": false,
                 "inputValues": [],
                 "composition": {
                   "minQuantity": 0,

--- a/react/__mocks__/productPizza.json
+++ b/react/__mocks__/productPizza.json
@@ -180,7 +180,7 @@
               {
                 "id": "pizza_composition_Pizza flavor",
                 "name": "pizza_composition",
-                "required": false,
+                "required": true,
                 "inputValues": [],
                 "composition": {
                   "minQuantity": 1,
@@ -203,7 +203,7 @@
               {
                 "id": "drinks_size_double_Choose 2 drinks",
                 "name": "drinks_size_double",
-                "required": false,
+                "required": true,
                 "inputValues": [],
                 "composition": {
                   "minQuantity": 2,
@@ -253,7 +253,7 @@
               {
                 "id": "pizza_extra_ingredients_Extra",
                 "name": "pizza_extra_ingredients",
-                "required": false,
+                "required": true,
                 "inputValues": [],
                 "composition": {
                   "minQuantity": 0,
@@ -321,6 +321,7 @@
               {
                 "id": "pizza_basic_ingredients_pizza_basic_ingredients",
                 "name": "pizza_basic_ingredients",
+                "required": true,
                 "inputValues": [],
                 "composition": {
                   "minQuantity": 0,

--- a/react/components/ProductAssemblyContext/Group.tsx
+++ b/react/components/ProductAssemblyContext/Group.tsx
@@ -25,7 +25,7 @@ type SetInputValueAction = {
 
 export const ProductAssemblyDispatchContext = createContext<Dispatch<DispatchAction>>(() => { })
 
-export const ProductAssemblyGroupContext = createContext<AssemblyOptionGroupType | undefined>(undefined)
+export const ProductAssemblyGroupContext = createContext<AssemblyOptionGroupState | undefined>(undefined)
 
 export const ProductAssemblyGroupContextProvider: FC<ProductAssemblyGroupContextProviderProps> = ({ assemblyOption, children }) => {
   const path = getGroupPath(assemblyOption.treePath)
@@ -39,7 +39,7 @@ export const ProductAssemblyGroupContextProvider: FC<ProductAssemblyGroupContext
     return acc
   }, {})
 
-  const initialState: AssemblyOptionGroupType = {
+  const initialState: AssemblyOptionGroupState = {
     ...assemblyOption,
     path,
     quantitySum: quantitySum,
@@ -77,7 +77,7 @@ function getGroupPath(assemblyTreePath?: TreePath[]) {
 }
 
 interface ProductAssemblyGroupContextProviderProps {
-  assemblyOption: AssemblyOptionGroupType
+  assemblyOption: AssemblyOptionGroupState
 }
 
 export const useProductAssemblyGroupDispatch = () =>
@@ -86,11 +86,11 @@ export const useProductAssemblyGroupDispatch = () =>
 export const useProductAssemblyGroupState = () =>
   useContext(ProductAssemblyGroupContext)
 
-function reducer(state: AssemblyOptionGroupType, action: DispatchAction): AssemblyOptionGroupType {
+function reducer(state: AssemblyOptionGroupState, action: DispatchAction): AssemblyOptionGroupState {
   switch (action.type) {
     case 'SET_INPUT_VALUE': {
       const { groupPath, inputValue, inputValueLabel } = action.args
-      let groupState = path(groupPath, state) as AssemblyOptionGroupType
+      let groupState = path(groupPath, state) as AssemblyOptionGroupState
 
       groupState.valuesOfInputValues = {
         ...groupState.valuesOfInputValues,

--- a/react/components/ProductAssemblyContext/Group.tsx
+++ b/react/components/ProductAssemblyContext/Group.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, Dispatch, useReducer, FC } from 'reac
 import { path } from 'ramda'
 import { GROUP_TYPES } from '../../modules/assemblyGroupType'
 
-type DispatchAction = SetQuantityAction | SetInputValueAction
+type DispatchAction = SetQuantityAction | SetInputValueAction | OptinAction
 
 type SetQuantityAction = {
   type: 'SET_QUANTITY'
@@ -19,6 +19,13 @@ type SetInputValueAction = {
   args: {
     inputValueLabel: string
     inputValue: string
+    groupPath: string[]
+  }
+}
+
+type OptinAction = {
+  type: 'OPTIN',
+  args: {
     groupPath: string[]
   }
 }
@@ -43,6 +50,7 @@ export const ProductAssemblyGroupContextProvider: FC<ProductAssemblyGroupContext
     ...assemblyOption,
     path,
     quantitySum: quantitySum,
+    optin: assemblyOption.required,
     valuesOfInputValues,
   }
 
@@ -88,6 +96,14 @@ export const useProductAssemblyGroupState = () =>
 
 function reducer(state: AssemblyOptionGroupState, action: DispatchAction): AssemblyOptionGroupState {
   switch (action.type) {
+    case 'OPTIN': {
+      const { groupPath } = action.args
+      let groupState = path(groupPath, state) as AssemblyOptionGroupState
+
+      groupState.optin = !groupState.optin
+
+      return { ...state }
+    }
     case 'SET_INPUT_VALUE': {
       const { groupPath, inputValue, inputValueLabel } = action.args
       let groupState = path(groupPath, state) as AssemblyOptionGroupState

--- a/react/components/ProductAssemblyOptions/InputValue/useInputValue.tsx
+++ b/react/components/ProductAssemblyOptions/InputValue/useInputValue.tsx
@@ -5,7 +5,7 @@ interface OnChangeParams {
 }
 
 export default function useInputValue(inputValueInfo: InputValue): [string, (param: OnChangeParams) => void] {
-  const { path, valuesOfInputValues } = useProductAssemblyGroupState() as AssemblyOptionGroupType
+  const { path, valuesOfInputValues } = useProductAssemblyGroupState() as AssemblyOptionGroupState
   const dispatch = useProductAssemblyGroupDispatch()
 
   const onChange = ({ value }: OnChangeParams) => {
@@ -25,7 +25,7 @@ export default function useInputValue(inputValueInfo: InputValue): [string, (par
 }
 
 export function useInputValueId(inputValueInfo: InputValue) {
-  const { path } = useProductAssemblyGroupState() as AssemblyOptionGroupType
+  const { path } = useProductAssemblyGroupState() as AssemblyOptionGroupState
 
   return inputValueInfo.label + path.join('-')
 }

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemInputValues.test.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemInputValues.test.tsx
@@ -21,7 +21,7 @@ function renderComponent() {
 
 mockUseProduct.mockImplementation(() => ({
   product: productAttachment.data.product,
-  selectedItem: productAttachment.data.product.items[0],
+  selectedItem: productAttachment.data.product.items[6],
   selectedQuantity: 1
 }))
 

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemInputValues.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemInputValues.tsx
@@ -6,7 +6,7 @@ import BooleanInputValue from './InputValue/BooleanInputValue'
 import { InputValueType } from '../../modules/inputValueType'
 
 const ProductAssemblyOptionItemInputValues: FC = () => {
-  const { inputValues } = useProductAssemblyGroupState() as AssemblyOptionGroupType
+  const { inputValues } = useProductAssemblyGroupState() as AssemblyOptionGroupState
 
   return (
     <Fragment>

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemPrice.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemPrice.tsx
@@ -4,7 +4,7 @@ import ProductPrice from 'vtex.store-components/ProductPrice'
 import { useProductAssemblyItem } from '../ProductAssemblyContext/Item'
 
 const sumAssembliesPrice = (
-  assemblyOptions: Record<string, AssemblyOptionGroupType>
+  assemblyOptions: Record<string, AssemblyOptionGroupState>
 ): number => {
   const assembliesGroupItems = Object.values(assemblyOptions)
 

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.test.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import { render, fireEvent } from '@vtex/test-tools/react'
+import ProductAssemblyOptions from '../../ProductAssemblyOptions'
+import InputValue from './ProductAssemblyOptionItemInputValues'
+import productAttachment from '../../__mocks__/productAttachment.json'
+import useProduct, { ProductContext } from 'vtex.product-context/useProduct'
+import { useProductDispatch } from 'vtex.product-context/ProductDispatchContext'
+import ProductAssemblyOptionItemName from './ProductAssemblyOptionItemName'
+
+const mockedUseProductDispatch = useProductDispatch as jest.Mock<() => jest.Mock>
+const mockUseProduct = useProduct as jest.Mock<ProductContext>
+
+function renderComponent() {
+  return render(
+    <ProductAssemblyOptions>
+      <ProductAssemblyOptionItemName />
+      <InputValue />
+    </ProductAssemblyOptions>
+  )
+}
+
+let mockedDispatch = jest.fn()
+beforeEach(() => {
+  mockedDispatch = jest.fn()
+  mockedUseProductDispatch.mockImplementation(() => mockedDispatch)
+  mockUseProduct.mockReset()
+})
+
+describe('Product with required assembly', () => {
+  beforeEach(() => {
+    mockUseProduct.mockImplementation(() => ({
+      product: productAttachment.data.product,
+      selectedItem: productAttachment.data.product.items[6],
+      selectedQuantity: 1
+    }))
+  })
+
+  test('should NOT show Add Customization and Remove button', () => {
+    const { queryByText } = renderComponent()
+  
+    const addButton = queryByText(/Add Customization/)
+    expect(addButton).toBeFalsy()
+
+    const removeButton = queryByText(/Remove/)
+    expect(removeButton).toBeFalsy()
+  })
+
+  test('should show child elements', () => {
+    const { getByText, getByLabelText } = renderComponent()
+  
+    getByText(/Customization/)
+    getByLabelText(/Font/)
+  })
+})
+
+describe('Product with not required assembly', () => {
+  beforeEach(() => {
+    mockUseProduct.mockImplementation(() => ({
+      product: productAttachment.data.product,
+      selectedItem: productAttachment.data.product.items[0],
+      selectedQuantity: 1
+    }))
+  })
+
+  test('Add Customization and Remove button', () => {
+    const { getByLabelText, getByText, queryByLabelText } = renderComponent()
+
+    const addButton = getByText(/Add Customization/)
+    fireEvent.click(addButton)
+
+    // Show child elements
+    getByLabelText(/Font/)
+
+    const removeButton = getByText(/Remove/)
+    fireEvent.click(removeButton)
+
+    // No child elements
+    const fontInput = queryByLabelText(/Font/)
+    expect(fontInput).toBeFalsy()
+  })
+})

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
@@ -7,7 +7,7 @@ import { ProductAssemblyItemProvider } from '../ProductAssemblyContext/Item'
 import styles from './styles.css'
 
 const ProductAssemblyOptionsGroup: FC = ({ children }) => {
-  const assemblyOptionGroup = useProductAssemblyGroupState() as AssemblyOptionGroupType
+  const assemblyOptionGroup = useProductAssemblyGroupState() as AssemblyOptionGroupState
 
   useAssemblyOptionsModifications(assemblyOptionGroup)
 

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
@@ -41,6 +41,7 @@ const ProductAssemblyOptionsGroup: FC = ({ children }) => {
               {assemblyOptionGroup.required === false &&
                 <div>
                   <Button
+                    size="small"
                     collapseRight
                     variation="tertiary"
                     onClick={changeOptinInput}>

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
@@ -1,34 +1,70 @@
 import React, { FC, Fragment } from 'react'
 
-import { useProductAssemblyGroupState } from '../ProductAssemblyContext/Group'
+import { useProductAssemblyGroupState, useProductAssemblyGroupDispatch } from '../ProductAssemblyContext/Group'
 import useAssemblyOptionsModifications from '../../modules/useAssemblyOptionsModifications'
 import ProductAssemblyOptionItemInputValues from './ProductAssemblyOptionItemInputValues'
 import { ProductAssemblyItemProvider } from '../ProductAssemblyContext/Item'
+import { Button } from 'vtex.styleguide'
 import styles from './styles.css'
 
 const ProductAssemblyOptionsGroup: FC = ({ children }) => {
   const assemblyOptionGroup = useProductAssemblyGroupState() as AssemblyOptionGroupState
+  const dispatch = useProductAssemblyGroupDispatch()
 
   useAssemblyOptionsModifications(assemblyOptionGroup)
 
+  const changeOptinInput = () => {
+    dispatch({
+      type: 'OPTIN',
+      args: {
+        groupPath: assemblyOptionGroup.path,
+      }
+    })
+  }
+
   return (
     <Fragment>
-      <div className="ttc-s pv4 c-muted-2 t-small">
-        {assemblyOptionGroup.groupName}
-      </div>
-      {assemblyOptionGroup.items
-        ? Object.values(assemblyOptionGroup.items).map(item => {
-            return (
-              <ProductAssemblyItemProvider item={item} key={item.id}>
-                <div
-                  className={`${styles.itemContainer} hover-bg-muted-5 bb b--muted-5 pa3`}
-                >
-                  {children}
+      {assemblyOptionGroup.optin === false
+        ? (
+          <Button
+            variation="secondary"
+            onClick={changeOptinInput}>
+            Add {assemblyOptionGroup.id}
+          </Button>
+        )
+        : (
+          <Fragment>
+            <div className="flex justify-between">
+              <div className="ttc-s pv4 c-muted-2 t-small">
+                {assemblyOptionGroup.groupName}
+              </div>
+              {assemblyOptionGroup.required === false &&
+                <div>
+                  <Button
+                    collapseRight
+                    variation="tertiary"
+                    onClick={changeOptinInput}>
+                    Remove
+                  </Button>
                 </div>
-              </ProductAssemblyItemProvider>
-            )
-          })
-        : <ProductAssemblyOptionItemInputValues />
+              }
+            </div>
+            {assemblyOptionGroup.items
+              ? Object.values(assemblyOptionGroup.items).map(item => {
+                return (
+                  <ProductAssemblyItemProvider item={item} key={item.id}>
+                    <div
+                      className={`${styles.itemContainer} hover-bg-muted-5 bb b--muted-5 pa3`}
+                    >
+                      {children}
+                    </div>
+                  </ProductAssemblyItemProvider>
+                )
+              })
+              : <ProductAssemblyOptionItemInputValues />
+            }
+          </Fragment>
+        )
       }
     </Fragment>
   )

--- a/react/modules/useAssemblyOptions.test.tsx
+++ b/react/modules/useAssemblyOptions.test.tsx
@@ -20,4 +20,5 @@ test('it should return inputValues', () => {
   expect(value['Customization'].inputValues).toBe(
     productAttachment.data.product.itemMetadata.items[0].assemblyOptions[0].inputValues
   )
+  expect(value['Customization'].required).toBe(false)
 })

--- a/react/modules/useAssemblyOptions.test.tsx
+++ b/react/modules/useAssemblyOptions.test.tsx
@@ -22,3 +22,20 @@ test('it should return inputValues', () => {
   )
   expect(value['Customization'].required).toBe(false)
 })
+
+test('it should return inputValues of the selected SKU', () => {
+  mockUseProduct.mockImplementation(() => ({
+    product: productAttachment.data.product,
+    selectedItem: productAttachment.data.product.items[6],
+    selectedQuantity: 1
+  }))
+
+  const { result } = renderHook(() => parseAssemblyOptions())
+  const value = result.current!
+
+  expect(value['Customization']).toBeDefined()
+  expect(value['Customization'].inputValues).toBe(
+    productAttachment.data.product.itemMetadata.items[2].assemblyOptions[0].inputValues
+  )
+  expect(value['Customization'].required).toBe(true)
+})

--- a/react/modules/useAssemblyOptions.ts
+++ b/react/modules/useAssemblyOptions.ts
@@ -9,7 +9,7 @@ const splitGroupName = compose(
 )
 
 type PriceMap = Record<string, Record<string, Record<string, number>>>
-type ParsedAssemblyOptions = Record<string, AssemblyOptionGroupType>
+type ParsedAssemblyOptions = Record<string, AssemblyOptionGroupState>
 
 const findItemMetadata = (id: string) => find<MetadataItem>(propEq('id', id))
 

--- a/react/modules/useAssemblyOptions.ts
+++ b/react/modules/useAssemblyOptions.ts
@@ -90,6 +90,7 @@ const parseAssemblyOptions = (
           treePath: currentTreePath,
           type: getGroupType(assemblyOption),
           inputValues: assemblyOption.inputValues,
+          required: assemblyOption.required,
           items,
         } as AssemblyOptionGroup
       } else {
@@ -101,6 +102,7 @@ const parseAssemblyOptions = (
           treePath: currentTreePath,
           type: getGroupType(assemblyOption),
           inputValues: assemblyOption.inputValues,
+          required: assemblyOption.required,
           items: undefined,
         } as AssemblyOptionGroupInputValue
       }

--- a/react/modules/useAssemblyOptionsModifications.ts
+++ b/react/modules/useAssemblyOptionsModifications.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { pick } from 'ramda'
 import { useProductDispatch } from 'vtex.product-context/ProductDispatchContext'
 
-export default function useAssemblyOptionsModifications(localState: AssemblyOptionGroupType) {
+export default function useAssemblyOptionsModifications(localState: AssemblyOptionGroupState) {
   const dispatch = useProductDispatch()
 
   useEffect(() => {
@@ -22,7 +22,7 @@ export default function useAssemblyOptionsModifications(localState: AssemblyOpti
   }, [localState, dispatch])
 }
 
-function isGroupValid(group: AssemblyOptionGroupType) {
+function isGroupValid(group: AssemblyOptionGroupState) {
   const items = Object.values(group.items || {})
   const itemsToBeAdded = items.reduce((acc, { quantity }) => acc + quantity, 0)
   const isValid = (
@@ -71,7 +71,7 @@ interface BuyButtonItem {
   children: Record<string, BuyButtonItem[]> | null
 }
 
-function parseItemChildren(children: Record<string, AssemblyOptionGroupType>) {
+function parseItemChildren(children: Record<string, AssemblyOptionGroupState>) {
   const groupIds = Object.keys(children)
   const result: Record<string, BuyButtonItem[]> = {}
 

--- a/react/typings/ProjectTypings.d.ts
+++ b/react/typings/ProjectTypings.d.ts
@@ -108,7 +108,7 @@ declare global {
     quantitySum: number
   }
 
-  type AssemblyOptionGroupType = AssemblyOptionGroup | AssemblyOptionGroupInputValue
+  type AssemblyOptionGroupState = AssemblyOptionGroup | AssemblyOptionGroupInputValue
 
   interface AssemblyItem {
     image: string
@@ -120,6 +120,6 @@ declare global {
     seller: string
     initialQuantity: number
     quantity: number
-    children: Record<string, AssemblyOptionGroupType> | null
+    children: Record<string, AssemblyOptionGroupState> | null
   }
 }

--- a/react/typings/ProjectTypings.d.ts
+++ b/react/typings/ProjectTypings.d.ts
@@ -85,9 +85,10 @@ declare global {
     groupName: string
     treePath: TreePath[]
     type: GroupTypes
-    valuesOfInputValues: Record<string, string>
     inputValues: InputValue[]
 
+    valuesOfInputValues: Record<string, string>
+    optin: boolean
     path: string[]
     quantitySum: number
   }
@@ -101,9 +102,10 @@ declare global {
     groupName: string
     treePath: TreePath[]
     type: GroupTypes
-    valuesOfInputValues: Record<string, string>
     inputValues: InputValue[]
 
+    valuesOfInputValues: Record<string, string>
+    optin: boolean
     path: string[]
     quantitySum: number
   }

--- a/react/typings/ProjectTypings.d.ts
+++ b/react/typings/ProjectTypings.d.ts
@@ -21,6 +21,7 @@ declare global {
   interface AssemblyOption {
     id: string
     name: string
+    required: boolean
     composition: Composition | null
     inputValues: InputValue[]
   }
@@ -77,6 +78,7 @@ declare global {
 
   interface AssemblyOptionGroup {
     id: string
+    required: boolean
     minQuantity: number
     maxQuantity: number
     items: Record<string, AssemblyItem>
@@ -92,6 +94,7 @@ declare global {
 
   interface AssemblyOptionGroupInputValue {
     id: string
+    required: boolean
     minQuantity: undefined
     maxQuantity: undefined
     items: undefined


### PR DESCRIPTION
**Review this commit by commit**

---

We changed the behaviour of assembly options.

If attachment is not marked as required |
---|
![image](https://user-images.githubusercontent.com/284515/65287551-0a4d9500-db1a-11e9-9cdd-373e9d8e1467.png)

<br/>
<br/>

We now show a button for the user to optin to use this attachment |
---|
![image](https://user-images.githubusercontent.com/284515/65287564-146f9380-db1a-11e9-8780-f1d9b5871173.png)

<br/>

The user might want to remove it as well to go back to the default state |
---|
![image](https://user-images.githubusercontent.com/284515/65287590-22251900-db1a-11e9-8c42-1555ffa885af.png)

<br/>
<br/>

If the attachment is required, the options are open by default and the Remove button is not rendered |
---|
![image](https://user-images.githubusercontent.com/284515/65287626-3a953380-db1a-11e9-9625-c64b790f8140.png)


---

Item with required assembly options: https://breno--storecomponents.myvtex.com/custom-bell/p
Item with not required assembly options: https://breno--storecomponents.myvtex.com/star-color-top/p?skuId=2000564