### PR TITLE
Add CSS class handles to the InputValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CSS class handles to the ProductAssemblyOptions' InputValues
 
 ## [2.6.2] - 2019-09-27
 

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,8 @@
     "vtex.product-details": "1.x",
     "vtex.product-context": "0.x",
     "vtex.device-detector": "0.x",
-    "vtex.flex-layout": "0.x"
+    "vtex.flex-layout": "0.x",
+    "vtex.css-handles": "0.x"
   },
   "builders": {
     "store": "0.x",

--- a/react/__mocks__/vtex.css-handles.js
+++ b/react/__mocks__/vtex.css-handles.js
@@ -1,3 +1,7 @@
 export const useCssHandles = something => {
   return something
 }
+
+export const applyModifiers = something => {
+  return something
+}

--- a/react/__mocks__/vtex.css-handles.js
+++ b/react/__mocks__/vtex.css-handles.js
@@ -1,0 +1,3 @@
+export const useCssHandles = something => {
+  return something
+}

--- a/react/components/ProductAssemblyOptions/InputValue/BooleanInputValue.tsx
+++ b/react/components/ProductAssemblyOptions/InputValue/BooleanInputValue.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react'
 import { Checkbox } from 'vtex.styleguide'
 import useInputValue, { useInputValueId } from './useInputValue'
+import styles from '../styles.css'
 
 const BooleanInputValue: FC<Props> = ({ inputValueInfo }) => {
   const [state, onChange] = useInputValue(inputValueInfo)
@@ -12,7 +13,7 @@ const BooleanInputValue: FC<Props> = ({ inputValueInfo }) => {
   }
 
   return (
-    <div className="mb4">
+    <div className={`${styles.booleanInputValue} mb4`}>
       <Checkbox
         id={id}
         value={inputValueInfo.label}

--- a/react/components/ProductAssemblyOptions/InputValue/BooleanInputValue.tsx
+++ b/react/components/ProductAssemblyOptions/InputValue/BooleanInputValue.tsx
@@ -1,7 +1,9 @@
 import React, { FC } from 'react'
 import { Checkbox } from 'vtex.styleguide'
 import useInputValue, { useInputValueId } from './useInputValue'
-import styles from '../styles.css'
+import { useCssHandles } from 'vtex.css-handles'
+
+const CSS_HANDLES = [ 'booleanInputValue' ] as const
 
 const BooleanInputValue: FC<Props> = ({ inputValueInfo }) => {
   const [state, onChange] = useInputValue(inputValueInfo)
@@ -12,8 +14,9 @@ const BooleanInputValue: FC<Props> = ({ inputValueInfo }) => {
     onChange({ value })
   }
 
+  const handles = useCssHandles(CSS_HANDLES)
   return (
-    <div className={`${styles.booleanInputValue} mb4`}>
+    <div className={`${handles.booleanInputValue} mb4`}>
       <Checkbox
         id={id}
         value={inputValueInfo.label}

--- a/react/components/ProductAssemblyOptions/InputValue/OptionBox.tsx
+++ b/react/components/ProductAssemblyOptions/InputValue/OptionBox.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react'
 import classNames from 'classnames'
 import slugify from '../../../modules/slugify'
 import styles from '../styles.css'
-import { useCssHandles } from 'vtex.css-handles'
+import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 
 const CSS_HANDLES = [
   'inputValueOptionBox',
@@ -15,8 +15,7 @@ const OptionBox: FC<Props> = ({ option, selected, onClick, onKeyDown }) => {
       role="button"
       tabIndex={0}
       className={classNames(
-        handles.inputValueOptionBox,
-        `${handles.inputValueOptionBox}--${slugify(option)}`,
+        applyModifiers(handles.inputValueOptionBox, slugify(option)),
         'relative di pointer flex items-center outline-0 mr4',
       )}
       onClick={onClick}

--- a/react/components/ProductAssemblyOptions/InputValue/OptionBox.tsx
+++ b/react/components/ProductAssemblyOptions/InputValue/OptionBox.tsx
@@ -2,15 +2,21 @@ import React, { FC } from 'react'
 import classNames from 'classnames'
 import slugify from '../../../modules/slugify'
 import styles from '../styles.css'
+import { useCssHandles } from 'vtex.css-handles'
+
+const CSS_HANDLES = [
+  'inputValueOptionBox',
+] as const
 
 const OptionBox: FC<Props> = ({ option, selected, onClick, onKeyDown }) => {
+  const handles = useCssHandles(CSS_HANDLES)
   return (
     <div
       role="button"
       tabIndex={0}
       className={classNames(
-        styles.inputValueOptionBox,
-        `${styles.inputValueOptionBox}--${slugify(option)}`,
+        handles.inputValueOptionBox,
+        `${handles.inputValueOptionBox}--${slugify(option)}`,
         'relative di pointer flex items-center outline-0 mr4',
       )}
       onClick={onClick}

--- a/react/components/ProductAssemblyOptions/InputValue/OptionsInputValue.tsx
+++ b/react/components/ProductAssemblyOptions/InputValue/OptionsInputValue.tsx
@@ -2,6 +2,7 @@ import React, { FC, useMemo } from 'react'
 import { Dropdown } from 'vtex.styleguide'
 import useInputValue from './useInputValue'
 import OptionBox from './OptionBox'
+import styles from '../styles.css'
 
 const DropdownOptions: FC<Props> = ({ inputValueInfo }) => {
   const [state, onChange] = useInputValue(inputValueInfo)
@@ -16,7 +17,7 @@ const DropdownOptions: FC<Props> = ({ inputValueInfo }) => {
   }, [inputValueInfo.domain])
 
   return (
-    <div className="mb4">
+    <div className={`${styles.optionsInputValueDropdown} mb4`}>
       <Dropdown
         value={state}
         onChange={handleChange}
@@ -66,13 +67,13 @@ const BoxOptions: FC<Props> = ({ inputValueInfo }) => {
   }
 
   return (
-    <div className="mb4">
-      <div className="mb3">
-        <span className="c-muted-1 t-small overflow-hidden">
+    <div className={`${styles.optionsInputValue} mb4`}>
+      <div className={`${styles.optionsInputValueLabelContainer} mb3`}>
+        <span className={`${styles.optionsInputValueLabel} c-muted-1 t-small overflow-hidden`}>
           {inputValueInfo.label}
         </span>
       </div>
-      <div className="inline-flex flex-wrap flex items-center">
+      <div className={`${styles.optionsInputValueOptionBoxContainer} inline-flex flex-wrap flex items-center`}>
         {inputValueInfo.domain.map(option =>
           <OptionBox
             key={option}

--- a/react/components/ProductAssemblyOptions/InputValue/OptionsInputValue.tsx
+++ b/react/components/ProductAssemblyOptions/InputValue/OptionsInputValue.tsx
@@ -2,10 +2,12 @@ import React, { FC, useMemo } from 'react'
 import { Dropdown } from 'vtex.styleguide'
 import useInputValue from './useInputValue'
 import OptionBox from './OptionBox'
-import styles from '../styles.css'
+import { useCssHandles } from 'vtex.css-handles'
 
 const DropdownOptions: FC<Props> = ({ inputValueInfo }) => {
   const [state, onChange] = useInputValue(inputValueInfo)
+  const CSS_HANDLES = ['optionsInputValueDropdown'] as const
+  const handles = useCssHandles(CSS_HANDLES)
 
   const handleChange = (e: any) => {
     const value = e.target.value
@@ -13,22 +15,33 @@ const DropdownOptions: FC<Props> = ({ inputValueInfo }) => {
   }
 
   const options = useMemo(() => {
-    return inputValueInfo.domain.map((option) => ({ value: option, label: option }))
+    return inputValueInfo.domain.map(option => ({
+      value: option,
+      label: option,
+    }))
   }, [inputValueInfo.domain])
 
   return (
-    <div className={`${styles.optionsInputValueDropdown} mb4`}>
+    <div className={`${handles.optionsInputValueDropdown} mb4`}>
       <Dropdown
         value={state}
         onChange={handleChange}
         label={inputValueInfo.label}
-        options={options} />
+        options={options}
+      />
     </div>
   )
 }
 
 const BoxOptions: FC<Props> = ({ inputValueInfo }) => {
   const [state, onChange] = useInputValue(inputValueInfo)
+  const CSS_HANDLES = [
+    'optionsInputValue',
+    'optionsInputValueLabelContainer',
+    'optionsInputValueLabel',
+    'optionsInputValueOptionBoxContainer',
+  ] as const
+  const handles = useCssHandles(CSS_HANDLES)
 
   const handleKeyDown = (event: KeyboardEvent) => {
     const selected = state as string
@@ -36,30 +49,30 @@ const BoxOptions: FC<Props> = ({ inputValueInfo }) => {
     const selectedIndex = options.indexOf(selected)
 
     switch (event.key) {
-      case "ArrowRight": {
+      case 'ArrowRight': {
         const count = options.length
         const nextSelectedIndex = (selectedIndex + 1) % count
         const newValue = options[nextSelectedIndex]
         onChange({ value: newValue })
-        break;
+        break
       }
-      case "ArrowLeft": {
+      case 'ArrowLeft': {
         const count = options.length
         const previousSelectedIndex = (selectedIndex - 1 + count) % count
         const newValue = options[previousSelectedIndex]
         onChange({ value: newValue })
-        break;
+        break
       }
-      case "Home": {
+      case 'Home': {
         const newValue = options[0]
         onChange({ value: newValue })
-        break;
+        break
       }
-      case "End": {
+      case 'End': {
         const count = options.length
         const newValue = options[count - 1]
         onChange({ value: newValue })
-        break;
+        break
       }
       default: {
       }
@@ -67,30 +80,40 @@ const BoxOptions: FC<Props> = ({ inputValueInfo }) => {
   }
 
   return (
-    <div className={`${styles.optionsInputValue} mb4`}>
-      <div className={`${styles.optionsInputValueLabelContainer} mb3`}>
-        <span className={`${styles.optionsInputValueLabel} c-muted-1 t-small overflow-hidden`}>
+    <div className={`${handles.optionsInputValue} mb4`}>
+      <div className={`${handles.optionsInputValueLabelContainer} mb3`}>
+        <span
+          className={`${handles.optionsInputValueLabel} c-muted-1 t-small overflow-hidden`}
+        >
           {inputValueInfo.label}
         </span>
       </div>
-      <div className={`${styles.optionsInputValueOptionBoxContainer} inline-flex flex-wrap flex items-center`}>
-        {inputValueInfo.domain.map(option =>
+      <div
+        className={`${handles.optionsInputValueOptionBoxContainer} inline-flex flex-wrap flex items-center`}
+      >
+        {inputValueInfo.domain.map(option => (
           <OptionBox
             key={option}
             onKeyDown={handleKeyDown}
             option={option}
             selected={state === option}
-            onClick={() => onChange({ value: option })} />
-        )}
+            onClick={() => onChange({ value: option })}
+          />
+        ))}
       </div>
     </div>
   )
 }
 
-const OptionsInputValue: FC<Props> = ({ optionsDisplay = 'select', inputValueInfo }) => {
-  return optionsDisplay === 'box'
-    ? <BoxOptions inputValueInfo={inputValueInfo} />
-    : <DropdownOptions inputValueInfo={inputValueInfo} />
+const OptionsInputValue: FC<Props> = ({
+  optionsDisplay = 'select',
+  inputValueInfo,
+}) => {
+  return optionsDisplay === 'box' ? (
+    <BoxOptions inputValueInfo={inputValueInfo} />
+  ) : (
+    <DropdownOptions inputValueInfo={inputValueInfo} />
+  )
 }
 
 export type OptionDisplay = 'select' | 'box' | 'smart'

--- a/react/components/ProductAssemblyOptions/InputValue/OptionsInputValue.tsx
+++ b/react/components/ProductAssemblyOptions/InputValue/OptionsInputValue.tsx
@@ -4,10 +4,17 @@ import useInputValue from './useInputValue'
 import OptionBox from './OptionBox'
 import { useCssHandles } from 'vtex.css-handles'
 
+const DROPDOWN_OPTIONS_HANDLES = ['optionsInputValueDropdown'] as const
+const BOX_OPTIONS_HANDLES = [
+  'optionsInputValue',
+  'optionsInputValueLabelContainer',
+  'optionsInputValueLabel',
+  'optionsInputValueOptionBoxContainer',
+] as const
+
 const DropdownOptions: FC<Props> = ({ inputValueInfo }) => {
   const [state, onChange] = useInputValue(inputValueInfo)
-  const CSS_HANDLES = ['optionsInputValueDropdown'] as const
-  const handles = useCssHandles(CSS_HANDLES)
+  const handles = useCssHandles(DROPDOWN_OPTIONS_HANDLES)
 
   const handleChange = (e: any) => {
     const value = e.target.value
@@ -35,13 +42,7 @@ const DropdownOptions: FC<Props> = ({ inputValueInfo }) => {
 
 const BoxOptions: FC<Props> = ({ inputValueInfo }) => {
   const [state, onChange] = useInputValue(inputValueInfo)
-  const CSS_HANDLES = [
-    'optionsInputValue',
-    'optionsInputValueLabelContainer',
-    'optionsInputValueLabel',
-    'optionsInputValueOptionBoxContainer',
-  ] as const
-  const handles = useCssHandles(CSS_HANDLES)
+  const handles = useCssHandles(BOX_OPTIONS_HANDLES)
 
   const handleKeyDown = (event: KeyboardEvent) => {
     const selected = state as string

--- a/react/components/ProductAssemblyOptions/InputValue/TextInputValue.tsx
+++ b/react/components/ProductAssemblyOptions/InputValue/TextInputValue.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react'
 import { Input } from 'vtex.styleguide'
 import useInputValue from './useInputValue'
+import styles from '../styles.css'
 
 const TextInputValue: FC<Props> = ({ inputValueInfo }) => {
   const [state, onChange] = useInputValue(inputValueInfo)
@@ -11,7 +12,7 @@ const TextInputValue: FC<Props> = ({ inputValueInfo }) => {
   }
 
   return (
-    <div className="mb4">
+    <div className={`${styles.textInputValue} mb4`}>
       <Input
         value={state}
         onChange={handleChange}

--- a/react/components/ProductAssemblyOptions/InputValue/TextInputValue.tsx
+++ b/react/components/ProductAssemblyOptions/InputValue/TextInputValue.tsx
@@ -1,7 +1,9 @@
 import React, { FC } from 'react'
 import { Input } from 'vtex.styleguide'
 import useInputValue from './useInputValue'
-import styles from '../styles.css'
+import { useCssHandles } from 'vtex.css-handles'
+
+const CSS_HANDLES = [ 'textInputValue' ] as const
 
 const TextInputValue: FC<Props> = ({ inputValueInfo }) => {
   const [state, onChange] = useInputValue(inputValueInfo)
@@ -11,8 +13,9 @@ const TextInputValue: FC<Props> = ({ inputValueInfo }) => {
     onChange({ value })
   }
 
+  const handles = useCssHandles(CSS_HANDLES)
   return (
-    <div className={`${styles.textInputValue} mb4`}>
+    <div className={`${handles.textInputValue} mb4`}>
       <Input
         value={state}
         onChange={handleChange}

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemQuantity.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemQuantity.tsx
@@ -3,10 +3,14 @@ import {
   useProductAssemblyItem,
 } from '../ProductAssemblyContext/Item'
 import { Checkbox, Radio, NumericStepper } from 'vtex.styleguide'
-import styles from './styles.css'
 import { GROUP_TYPES } from '../../modules/assemblyGroupType'
 import { useProductAssemblyGroupState, useProductAssemblyGroupDispatch } from '../ProductAssemblyContext/Group'
 import { withItem } from './withItem'
+import { useCssHandles } from 'vtex.css-handles'
+
+const CSS_HANDLES = [
+  'multipleItemQuantitySelector',
+] as const
 
 const Single: FC = () => {
   const { id, quantity } = useProductAssemblyItem() as AssemblyItem
@@ -87,8 +91,9 @@ const Multiple: FC = () => {
     quantity + 1 <= maxQuantity &&
     quantitySum + 1 <= groupMaxQuantity
 
+  const handles = useCssHandles(CSS_HANDLES)
   return (
-    <div className={styles.multipleItemQuantitySelector} data-testid={`multipleItemQuantitySelector-${id}`}>
+    <div className={handles.multipleItemQuantitySelector} data-testid={`multipleItemQuantitySelector-${id}`}>
       <NumericStepper
         lean
         value={quantity}

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
@@ -4,11 +4,16 @@ import { useProductAssemblyGroupState, useProductAssemblyGroupDispatch } from '.
 import useAssemblyOptionsModifications from '../../modules/useAssemblyOptionsModifications'
 import { ProductAssemblyItemProvider } from '../ProductAssemblyContext/Item'
 import { Button } from 'vtex.styleguide'
-import styles from './styles.css'
+import { useCssHandles } from 'vtex.css-handles'
+
+const CSS_HANDLES = [
+  'itemContainer',
+] as const
 
 const ProductAssemblyOptionsGroup: FC = ({ children }) => {
   const assemblyOptionGroup = useProductAssemblyGroupState() as AssemblyOptionGroupState
   const dispatch = useProductAssemblyGroupDispatch()
+  const handles = useCssHandles(CSS_HANDLES)
 
   useAssemblyOptionsModifications(assemblyOptionGroup)
 
@@ -54,7 +59,7 @@ const ProductAssemblyOptionsGroup: FC = ({ children }) => {
                 return (
                   <ProductAssemblyItemProvider item={item} key={item.id}>
                     <div
-                      className={`${styles.itemContainer} hover-bg-muted-5 bb b--muted-5 pa3`}
+                      className={`${handles.itemContainer} hover-bg-muted-5 bb b--muted-5 pa3`}
                     >
                       {children}
                     </div>

--- a/react/components/ProductAssemblyOptions/styles.css
+++ b/react/components/ProductAssemblyOptions/styles.css
@@ -13,6 +13,27 @@
 
 .inputValueOptionBox {}
 
+.booleanInputValue {
+}
+
+.optionsInputValue {
+}
+
+.optionsInputValueLabelContainer{
+}
+
+.optionsInputValueLabel{
+}
+
+.optionsInputValueDropdown {
+}
+
+.optionsInputValueOptionBoxContainer {
+}
+
+.textInputValue {
+}
+
 .frameAround {
   bottom: -0.25rem;
   top: -0.25rem;

--- a/react/components/ProductAssemblyOptions/styles.css
+++ b/react/components/ProductAssemblyOptions/styles.css
@@ -1,37 +1,8 @@
-.multipleItemQuantitySelector {
-}
-
 .multipleItemQuantitySelector button {
   background: transparent;
 }
 .multipleItemQuantitySelector input {
   background: transparent;
-}
-
-.itemContainer {
-}
-
-.inputValueOptionBox {}
-
-.booleanInputValue {
-}
-
-.optionsInputValue {
-}
-
-.optionsInputValueLabelContainer{
-}
-
-.optionsInputValueLabel{
-}
-
-.optionsInputValueDropdown {
-}
-
-.optionsInputValueOptionBoxContainer {
-}
-
-.textInputValue {
 }
 
 .frameAround {

--- a/react/typings/vtex.css-handles.d.ts
+++ b/react/typings/vtex.css-handles.d.ts
@@ -1,0 +1,3 @@
+declare module 'vtex.css-handles' {
+  export const useCssHandles: any
+}

--- a/react/typings/vtex.css-handles.d.ts
+++ b/react/typings/vtex.css-handles.d.ts
@@ -1,3 +1,4 @@
 declare module 'vtex.css-handles' {
   export const useCssHandles: any
+  export const applyModifiers: any
 }


### PR DESCRIPTION
Added css class handles to the InputValues of the ProductAssemblyOptions. With this, it is now possible to customize the fields on the image below:
![image](https://user-images.githubusercontent.com/8443580/65911604-3e8b4600-e3a3-11e9-875d-b1ea0c805481.png)
These field can be seen [here](https://csshandle2--storecomponents.myvtex.com/star-color-top/p) 