### PR TITLE
Close <a> tag in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Docs typo.
 
 ## [2.8.0] - 2020-03-26
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-📢 Don't fork this project. Use, contribute or open issues in<a href="https://github.com/vtex-apps/store-discussion"> Store Discussion
+📢 Don't fork this project. Use, contribute or open issues in<a href="https://github.com/vtex-apps/store-discussion"> Store Discussion</a>
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->


### PR DESCRIPTION
**What problem is this solving?**
In https://vtex.io/docs/components/product/vtex.product-customizer@2.8.0/ the links are not being rendered because the markdown is not well formatted.
