### PR TITLE
Select item when the user clicks on an item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
-- Select item when clicking in a Customize button of a Single selection group.
+### Fixed
+- Make selection when clicking in the item instead of needing to click on the Radio button.
 
 ## [2.8.2] - 2020-04-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Make selection when clicking in the item instead of needing to click on the Radio button.
+- Make selection when clicking in the item instead of needing to click on the Radio button or Checkbox.
 
 ## [2.8.2] - 2020-04-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Select item when clicking in a Customize button of a Single selection group.
 
 ## [2.8.2] - 2020-04-27
 ### Fixed

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionInputValues.test.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionInputValues.test.tsx
@@ -14,6 +14,7 @@ import productAttachment from '../../__fixtures__/productAttachment.json'
 import productRecursive from '../../__fixtures__/productRecursive.json'
 import ProductAssemblyOptionItemName from './ProductAssemblyOptionItemName'
 import ProductAssemblyOptionItemCustomize from './ProductAssemblyOptionItemCustomize'
+import ProductAssemblyOptionItemQuantity from './ProductAssemblyOptionItemQuantity'
 
 const mockedUseProductDispatch = useProductDispatch as jest.Mock<
   () => jest.Mock
@@ -161,7 +162,7 @@ test('should keep input values for recursive assemblies', async () => {
   const input = modal.getByLabelText('Line 1')
   fireEvent.change(input, { target: { value: 'Foobar' } })
 
-  expect(mockedDispatch.mock.calls).toHaveLength(6)
+  expect(mockedDispatch.mock.calls).toHaveLength(7)
   // eslint-disable-next-line prefer-destructuring
   const [lastCall] = mockedDispatch.mock.calls[5]
   expect(lastCall.type).toBe('SET_ASSEMBLY_OPTIONS')
@@ -183,4 +184,53 @@ test('should keep input values for recursive assemblies', async () => {
   // Check if input still set with "Foobar" previously typed
   const inputLine1 = getByLabelText('Line 1') as HTMLInputElement
   expect(inputLine1.value).toBe('Foobar')
+})
+
+test('should select option when click in customize', () => {
+  mockUseProduct.mockImplementation(() => ({
+    product: productRecursive.data.product,
+    selectedItem: productRecursive.data.product.items[0],
+    selectedQuantity: 1,
+  }))
+
+  const { getByText } = render(
+    <ProductAssemblyOptions>
+      <ProductAssemblyOptionItemName />
+      <InputValue />
+      <ProductAssemblyOptionItemQuantity />
+      <ProductAssemblyOptionItemCustomize>
+        <ProductAssemblyOptionItemName />
+        <InputValue />
+      </ProductAssemblyOptionItemCustomize>
+    </ProductAssemblyOptions>
+  )
+
+  const checkStyleguideCheckboxChecked = (container: HTMLElement) => {
+    const radioButton = container.querySelector('.fake-radio') as HTMLElement
+
+    const classList = Array.from(radioButton.classList)
+
+    return classList.includes('b--action-primary')
+  }
+
+  // Click on button Customize
+  const assembly = getByText('Bells add-ons 1-3 lines')
+
+  const isCheckedBefore = checkStyleguideCheckboxChecked(
+    assembly.parentElement as HTMLElement
+  )
+
+  expect(isCheckedBefore).toBe(false)
+
+  const customizeButton = assembly.parentElement?.querySelector(
+    '.vtex-button'
+  ) as HTMLElement
+
+  fireEvent.click(customizeButton)
+
+  const isCheckedAfter = checkStyleguideCheckboxChecked(
+    assembly.parentElement as HTMLElement
+  )
+
+  expect(isCheckedAfter).toBe(true)
 })

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
@@ -6,8 +6,13 @@ import { useDevice } from 'vtex.device-detector'
 import { useProductAssemblyItem } from '../ProductAssemblyContext/Item'
 import ProductAssemblyOptionsGroup from './ProductAssemblyOptionsGroup'
 import { imageUrlForSize } from './ProductAssemblyOptionItemImage'
-import { ProductAssemblyGroupContextProvider } from '../ProductAssemblyContext/Group'
+import {
+  ProductAssemblyGroupContextProvider,
+  useProductAssemblyGroupState,
+  useProductAssemblyGroupDispatch,
+} from '../ProductAssemblyContext/Group'
 import { withItem } from './withItem'
+import { GROUP_TYPES } from '../../modules/assemblyGroupType'
 
 const IMG_SIZE = 140
 
@@ -71,6 +76,30 @@ interface ButtonProps {
   collapse?: 'left' | 'right' | 'none'
 }
 
+/**
+ * If the Customize button is rendered inside a Single/Radio selection (min 1, max 1)
+ * When clicking in the Customize button it should select the item
+ */
+const useSelectSingle = () => {
+  const { id, quantity } = useProductAssemblyItem() as AssemblyItem
+  const { type, path } = useProductAssemblyGroupState() as AssemblyOptionGroup
+  const dispatch = useProductAssemblyGroupDispatch()
+
+  return () => {
+    if (quantity === 0 && type === GROUP_TYPES.SINGLE) {
+      dispatch({
+        type: 'SET_QUANTITY',
+        args: {
+          itemId: id,
+          newQuantity: 1,
+          type: GROUP_TYPES.SINGLE,
+          groupPath: path,
+        },
+      })
+    }
+  }
+}
+
 const ProductAssemblyOptionItemCustomize: FC<Props> = ({
   children,
   buttonProps = {},
@@ -79,6 +108,7 @@ const ProductAssemblyOptionItemCustomize: FC<Props> = ({
     name,
     children: itemChildren,
   } = useProductAssemblyItem() as AssemblyItem
+  const selectSingle = useSelectSingle()
   const { isMobile } = useDevice()
   const buttonCollapse = buttonProps.collapse
   const [modalOpen, setModalOpen] = useState(false)
@@ -87,13 +117,18 @@ const ProductAssemblyOptionItemCustomize: FC<Props> = ({
     return null
   }
 
+  const handleClick = () => {
+    setModalOpen(true)
+    selectSingle()
+  }
+
   const closeAction = () => setModalOpen(false)
 
   return (
     <Fragment>
       <Button
         variation="tertiary"
-        onClick={() => setModalOpen(true)}
+        onClick={handleClick}
         collapseLeft={buttonCollapse === 'left'}
         collapseRight={buttonCollapse === 'right'}
       >

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
@@ -6,13 +6,8 @@ import { useDevice } from 'vtex.device-detector'
 import { useProductAssemblyItem } from '../ProductAssemblyContext/Item'
 import ProductAssemblyOptionsGroup from './ProductAssemblyOptionsGroup'
 import { imageUrlForSize } from './ProductAssemblyOptionItemImage'
-import {
-  ProductAssemblyGroupContextProvider,
-  useProductAssemblyGroupState,
-  useProductAssemblyGroupDispatch,
-} from '../ProductAssemblyContext/Group'
+import { ProductAssemblyGroupContextProvider } from '../ProductAssemblyContext/Group'
 import { withItem } from './withItem'
-import { GROUP_TYPES } from '../../modules/assemblyGroupType'
 
 const IMG_SIZE = 140
 
@@ -76,30 +71,6 @@ interface ButtonProps {
   collapse?: 'left' | 'right' | 'none'
 }
 
-/**
- * If the Customize button is rendered inside a Single/Radio selection (min 1, max 1)
- * When clicking in the Customize button it should select the item
- */
-const useSelectSingle = () => {
-  const { id, quantity } = useProductAssemblyItem() as AssemblyItem
-  const { type, path } = useProductAssemblyGroupState() as AssemblyOptionGroup
-  const dispatch = useProductAssemblyGroupDispatch()
-
-  return () => {
-    if (quantity === 0 && type === GROUP_TYPES.SINGLE) {
-      dispatch({
-        type: 'SET_QUANTITY',
-        args: {
-          itemId: id,
-          newQuantity: 1,
-          type: GROUP_TYPES.SINGLE,
-          groupPath: path,
-        },
-      })
-    }
-  }
-}
-
 const ProductAssemblyOptionItemCustomize: FC<Props> = ({
   children,
   buttonProps = {},
@@ -108,7 +79,7 @@ const ProductAssemblyOptionItemCustomize: FC<Props> = ({
     name,
     children: itemChildren,
   } = useProductAssemblyItem() as AssemblyItem
-  const selectSingle = useSelectSingle()
+
   const { isMobile } = useDevice()
   const buttonCollapse = buttonProps.collapse
   const [modalOpen, setModalOpen] = useState(false)
@@ -119,7 +90,6 @@ const ProductAssemblyOptionItemCustomize: FC<Props> = ({
 
   const handleClick = () => {
     setModalOpen(true)
-    selectSingle()
   }
 
   const closeAction = () => setModalOpen(false)

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemQuantity.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemQuantity.tsx
@@ -70,6 +70,7 @@ const Toggle: FC = () => {
 
   return (
     <Checkbox
+      id={`${path}-selected-${id}`}
       disabled={disabled}
       name={`selected-${id}`}
       checked={selected}

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
@@ -1,6 +1,5 @@
 import React, { FC, Fragment } from 'react'
 import { Button } from 'vtex.styleguide'
-import { useCssHandles } from 'vtex.css-handles'
 import { IOMessage } from 'vtex.native-types'
 
 import {
@@ -9,13 +8,11 @@ import {
 } from '../ProductAssemblyContext/Group'
 import useAssemblyOptionsModifications from '../../modules/useAssemblyOptionsModifications'
 import { ProductAssemblyItemProvider } from '../ProductAssemblyContext/Item'
-
-const CSS_HANDLES = ['itemContainer'] as const
+import ProductAssemblyOptionsItem from './ProductAssemblyOptionsItem'
 
 const ProductAssemblyOptionsGroup: FC = ({ children }) => {
   const assemblyOptionGroup = useProductAssemblyGroupState() as AssemblyOptionGroupState
   const dispatch = useProductAssemblyGroupDispatch()
-  const handles = useCssHandles(CSS_HANDLES)
 
   useAssemblyOptionsModifications(assemblyOptionGroup)
 
@@ -63,11 +60,9 @@ const ProductAssemblyOptionsGroup: FC = ({ children }) => {
             Object.values(assemblyOptionGroup.items).map((item) => {
               return (
                 <ProductAssemblyItemProvider item={item} key={item.id}>
-                  <div
-                    className={`${handles.itemContainer} hover-bg-muted-5 bb b--muted-5 pa3`}
-                  >
+                  <ProductAssemblyOptionsItem>
                     {children}
-                  </div>
+                  </ProductAssemblyOptionsItem>
                 </ProductAssemblyItemProvider>
               )
             })

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsItem.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsItem.tsx
@@ -1,0 +1,70 @@
+import React, { FC } from 'react'
+import { useCssHandles } from 'vtex.css-handles'
+
+import { useProductAssemblyItem } from '../ProductAssemblyContext/Item'
+import {
+  useProductAssemblyGroupState,
+  useProductAssemblyGroupDispatch,
+} from '../ProductAssemblyContext/Group'
+import { GROUP_TYPES } from '../../modules/assemblyGroupType'
+
+const CSS_HANDLES = ['itemContainer'] as const
+
+/**
+ * If the Customize button is rendered inside a Single/Radio selection (min 1, max 1)
+ * When clicking in the Customize button it should select the item
+ */
+const useSelectSingle = () => {
+  const assemblyItem = useProductAssemblyItem() as AssemblyItem
+  const { type, path } = useProductAssemblyGroupState() as AssemblyOptionGroup
+  const dispatch = useProductAssemblyGroupDispatch()
+
+  if (
+    assemblyItem &&
+    assemblyItem.quantity === 0 &&
+    type === GROUP_TYPES.SINGLE
+  ) {
+    return () =>
+      dispatch({
+        type: 'SET_QUANTITY',
+        args: {
+          itemId: assemblyItem.id,
+          newQuantity: 1,
+          type: GROUP_TYPES.SINGLE,
+          groupPath: path,
+        },
+      })
+  }
+  return undefined
+}
+
+const ProductAssemblyOptionsItem: FC = ({ children }) => {
+  const handles = useCssHandles(CSS_HANDLES)
+  const selectSingle = useSelectSingle()
+
+  const handleClick = () => {
+    selectSingle?.()
+  }
+
+  const handleKeyDown = ({ key }: React.KeyboardEvent<HTMLDivElement>) => {
+    const SPACE = ' '
+    const ENTER = 'Enter'
+    if (key === SPACE || key === ENTER) {
+      selectSingle?.()
+    }
+  }
+
+  return (
+    <div
+      tabIndex={0}
+      role="button"
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      className={`${handles.itemContainer} hover-bg-muted-5 bb b--muted-5 pa3`}
+    >
+      {children}
+    </div>
+  )
+}
+
+export default ProductAssemblyOptionsItem

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsItem.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsItem.tsx
@@ -66,7 +66,7 @@ const ProductAssemblyOptionsItem: FC = ({ children }) => {
       role="button"
       onClick={handleClick}
       onKeyDown={handleKeyDown}
-      className={`${handles.itemContainer} hover-bg-muted-5 bb b--muted-5 pa3`}
+      className={`${handles.itemContainer} hover-bg-muted-5 bb b--muted-5 pa3 pointer`}
     >
       {children}
     </div>

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsItem.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsItem.tsx
@@ -10,47 +10,53 @@ import { GROUP_TYPES } from '../../modules/assemblyGroupType'
 
 const CSS_HANDLES = ['itemContainer'] as const
 
-/**
- * If the Customize button is rendered inside a Single/Radio selection (min 1, max 1)
- * When clicking in the Customize button it should select the item
- */
-const useSelectSingle = () => {
-  const assemblyItem = useProductAssemblyItem() as AssemblyItem
+const useSelectOption = () => {
+  const { id, quantity } = useProductAssemblyItem() as AssemblyItem
   const { type, path } = useProductAssemblyGroupState() as AssemblyOptionGroup
   const dispatch = useProductAssemblyGroupDispatch()
 
-  if (
-    assemblyItem &&
-    assemblyItem.quantity === 0 &&
-    type === GROUP_TYPES.SINGLE
-  ) {
+  if (quantity === 0 && type === GROUP_TYPES.SINGLE) {
     return () =>
       dispatch({
         type: 'SET_QUANTITY',
         args: {
-          itemId: assemblyItem.id,
+          itemId: id,
           newQuantity: 1,
           type: GROUP_TYPES.SINGLE,
           groupPath: path,
         },
       })
   }
+
+  if (type === GROUP_TYPES.TOGGLE) {
+    return () =>
+      dispatch({
+        type: 'SET_QUANTITY',
+        args: {
+          itemId: id,
+          newQuantity: quantity === 1 ? 0 : 1,
+          type: GROUP_TYPES.TOGGLE,
+          groupPath: path,
+        },
+      })
+  }
+
   return undefined
 }
 
 const ProductAssemblyOptionsItem: FC = ({ children }) => {
   const handles = useCssHandles(CSS_HANDLES)
-  const selectSingle = useSelectSingle()
+  const select = useSelectOption()
 
   const handleClick = () => {
-    selectSingle?.()
+    select?.()
   }
 
   const handleKeyDown = ({ key }: React.KeyboardEvent<HTMLDivElement>) => {
     const SPACE = ' '
     const ENTER = 'Enter'
     if (key === SPACE || key === ENTER) {
-      selectSingle?.()
+      select?.()
     }
   }
 


### PR DESCRIPTION
#### What problem is this solving?

Select an assembly option if the user clicks in the item. No need to click on the Radio button or Checkbox.

#### How to test it?

Linked workspace:
https://breno--storecomponents.myvtex.com/custom-bell/p

Also added a unit test.

Compare with master:
https://storetheme.vtex.com/custom-bell/p

#### Screenshots or example usage:

![Jun-29-2020 15-20-51](https://user-images.githubusercontent.com/284515/86041539-29b80d80-ba1c-11ea-8a3c-a517194ce3be.gif)

#### Describe alternatives you've considered, if any.

n/a

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/EQnKFGTw418nqpytB9/source.gif)
