### PR TITLE
Prop `initiallyOpened` to `assembly-options-group`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Prop `initiallyOpened` to `assembly-options-group`
+
 ## [2.8.3] - 2020-06-29
 ### Fixed
 - Make selection when clicking in the item instead of needing to click on the Radio button or Checkbox.

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,8 +32,8 @@ The Product Customizer allows a product's [attachments](https://help.vtex.com/tu
 
 | Prop name | Type | Description | Default value |
 |--------------|--------|--------------| --------|
-| `initiallyOpened` | Boolean | You should choose wheter the customization box should be initiallyOpened (`true`) or closed (`false`) . | `false` | 
-| `optionsDisplay` | String | You should choose between “box” or “select”. This will define whether the attachment's pre-defined options will be displayed to be selected in a Checkbox (`box`) or a dropdown list (`select`) . | `select` | 
+| `optionsDisplay` | `string` | You should choose between “box” or “select”. This will define whether the attachment's pre-defined options will be displayed to be selected in a Checkbox (`box`) or a dropdown list (`select`) . | `select` |
+| `initiallyOpened` | `enum` | The customization box is opened by default if the attachment is required and closed if it's not required. You can override this behavior by setting this prop to `always` making it be opened even if the attachment is not required. Leave it as `required` for the default behaviour. | `required` |
 
 ## Modus Operandi
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,10 +18,7 @@ The Product Customizer allows a product's [attachments](https://help.vtex.com/tu
   "product-assembly-options": {
     "children": [
       "assembly-option-input-values"
-    ],
-    "props": {
-      "initiallyOpened": true
-    }
+    ]
   },
   "assembly-option-input-values": {
     "props": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,8 +29,8 @@ The Product Customizer allows a product's [attachments](https://help.vtex.com/tu
 
 | Prop name | Type | Description | Default value |
 |--------------|--------|--------------| --------|
-| `optionsDisplay` | `string` | You should choose between “box” or “select”. This will define whether the attachment's pre-defined options will be displayed to be selected in a Checkbox (`box`) or a dropdown list (`select`) . | `select` |
-| `initiallyOpened` | `enum` | The customization box is opened by default if the attachment is required and closed if it's not required. You can override this behavior by setting this prop to `always` making it be opened even if the attachment is not required. Leave it as `required` for the default behaviour. | `required` |
+| `optionsDisplay` | `string` | Whether the attachment's pre-defined options will be displayed to be selected in a checkbox (`box`) or a dropdown list (`select`). | `select` |
+| `initiallyOpened` | `enum` | By default, the customization box is opened if the attachment is required and closed if it's not. You can override this behavior by setting this prop to `always`, making it be opened even if the attachment is not required. Leave it as `required` for the default behavior. | `required` |
 
 ## Modus Operandi
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,10 @@ The Product Customizer allows a product's [attachments](https://help.vtex.com/tu
   "product-assembly-options": {
     "children": [
       "assembly-option-input-values"
-    ]
+    ],
+    "props": {
+      "initiallyOpened": true
+    }
   },
   "assembly-option-input-values": {
     "props": {
@@ -29,6 +32,7 @@ The Product Customizer allows a product's [attachments](https://help.vtex.com/tu
 
 | Prop name | Type | Description | Default value |
 |--------------|--------|--------------| --------|
+| `initiallyOpened` | Boolean | You should choose wheter the customization box should be initiallyOpened (`true`) or closed (`false`) . | `false` | 
 | `optionsDisplay` | String | You should choose between “box” or “select”. This will define whether the attachment's pre-defined options will be displayed to be selected in a Checkbox (`box`) or a dropdown list (`select`) . | `select` | 
 
 ## Modus Operandi

--- a/react/ProductAssemblyOptions.tsx
+++ b/react/ProductAssemblyOptions.tsx
@@ -4,7 +4,7 @@ import useAssemblyOptions from './modules/useAssemblyOptions'
 import ProductAssemblyOptionsGroup from './components/ProductAssemblyOptions/ProductAssemblyOptionsGroup'
 import { ProductAssemblyGroupContextProvider } from './components/ProductAssemblyContext/Group'
 
-const ProductAssemblyOptions: FC<AssemblyOptionsGroup> = ({ children, initiallyOpened = false }) => {
+const ProductAssemblyOptions: FC<AssemblyOptionsGroup> = ({ children, initiallyOpened }) => {
   const assemblyOptions = useAssemblyOptions()
 
   if (!assemblyOptions) {

--- a/react/ProductAssemblyOptions.tsx
+++ b/react/ProductAssemblyOptions.tsx
@@ -5,7 +5,7 @@ import ProductAssemblyOptionsGroup from './components/ProductAssemblyOptions/Pro
 import { ProductAssemblyGroupContextProvider } from './components/ProductAssemblyContext/Group'
 
 interface Props {
-  initiallyOpened?: boolean
+  initiallyOpened?: 'always' | 'required'
 }
 
 const ProductAssemblyOptions: FC<Props> = ({ children, initiallyOpened }) => {

--- a/react/ProductAssemblyOptions.tsx
+++ b/react/ProductAssemblyOptions.tsx
@@ -4,7 +4,11 @@ import useAssemblyOptions from './modules/useAssemblyOptions'
 import ProductAssemblyOptionsGroup from './components/ProductAssemblyOptions/ProductAssemblyOptionsGroup'
 import { ProductAssemblyGroupContextProvider } from './components/ProductAssemblyContext/Group'
 
-const ProductAssemblyOptions: FC<AssemblyOptionsGroup> = ({ children, initiallyOpened }) => {
+interface Props {
+  initiallyOpened?: boolean
+}
+
+const ProductAssemblyOptions: FC<Props> = ({ children, initiallyOpened }) => {
   const assemblyOptions = useAssemblyOptions()
 
   if (!assemblyOptions) {
@@ -18,7 +22,9 @@ const ProductAssemblyOptions: FC<AssemblyOptionsGroup> = ({ children, initiallyO
           key={assemblyOptionId}
           assemblyOption={assemblyOptions[assemblyOptionId]}
         >
-          <ProductAssemblyOptionsGroup initiallyOpened={initiallyOpened}>{children}</ProductAssemblyOptionsGroup>
+          <ProductAssemblyOptionsGroup initiallyOpened={initiallyOpened}>
+            {children}
+          </ProductAssemblyOptionsGroup>
         </ProductAssemblyGroupContextProvider>
       ))}
     </Fragment>

--- a/react/ProductAssemblyOptions.tsx
+++ b/react/ProductAssemblyOptions.tsx
@@ -4,7 +4,7 @@ import useAssemblyOptions from './modules/useAssemblyOptions'
 import ProductAssemblyOptionsGroup from './components/ProductAssemblyOptions/ProductAssemblyOptionsGroup'
 import { ProductAssemblyGroupContextProvider } from './components/ProductAssemblyContext/Group'
 
-const ProductAssemblyOptions: FC = ({ children }) => {
+const ProductAssemblyOptions: FC<AssemblyOptionsGroup> = ({ children, initiallyOpened = false }) => {
   const assemblyOptions = useAssemblyOptions()
 
   if (!assemblyOptions) {
@@ -18,7 +18,7 @@ const ProductAssemblyOptions: FC = ({ children }) => {
           key={assemblyOptionId}
           assemblyOption={assemblyOptions[assemblyOptionId]}
         >
-          <ProductAssemblyOptionsGroup>{children}</ProductAssemblyOptionsGroup>
+          <ProductAssemblyOptionsGroup initiallyOpened={initiallyOpened}>{children}</ProductAssemblyOptionsGroup>
         </ProductAssemblyGroupContextProvider>
       ))}
     </Fragment>

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.test.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.test.tsx
@@ -13,9 +13,9 @@ const mockedUseProductDispatch = useProductDispatch as jest.Mock<
 >
 const mockUseProduct = useProduct as jest.Mock<ProductContext>
 
-function renderComponent() {
+function renderComponent(props: { initiallyOpened?: boolean } = {}) {
   return render(
-    <ProductAssemblyOptions>
+    <ProductAssemblyOptions {...props}>
       <ProductAssemblyOptionItemName />
       <InputValue />
     </ProductAssemblyOptions>
@@ -53,6 +53,16 @@ describe('Product with required assembly', () => {
 
     expect(getByText(/Customization/)).toBeTruthy()
     expect(getByLabelText(/Font/)).toBeTruthy()
+  })
+
+  it('should NOT show Add Customization and Remove button if initiallyOpened is set to true', () => {
+    const { queryByText } = renderComponent({ initiallyOpened: true })
+
+    const addButton = queryByText(/Add Customization/)
+    expect(addButton).toBeFalsy()
+
+    const removeButton = queryByText(/Remove/)
+    expect(removeButton).toBeFalsy()
   })
 })
 

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.test.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.test.tsx
@@ -13,7 +13,9 @@ const mockedUseProductDispatch = useProductDispatch as jest.Mock<
 >
 const mockUseProduct = useProduct as jest.Mock<ProductContext>
 
-function renderComponent(props: { initiallyOpened?: boolean } = {}) {
+function renderComponent(
+  props: { initiallyOpened?: 'required' | 'always' } = {}
+) {
   return render(
     <ProductAssemblyOptions {...props}>
       <ProductAssemblyOptionItemName />
@@ -55,8 +57,8 @@ describe('Product with required assembly', () => {
     expect(getByLabelText(/Font/)).toBeTruthy()
   })
 
-  it('should NOT show Add Customization and Remove button if initiallyOpened is set to true', () => {
-    const { queryByText } = renderComponent({ initiallyOpened: true })
+  it('should NOT show Add Customization and Remove button if initiallyOpened is set to always', () => {
+    const { queryByText } = renderComponent({ initiallyOpened: 'always' })
 
     const addButton = queryByText(/Add Customization/)
     expect(addButton).toBeFalsy()

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
@@ -34,7 +34,7 @@ const ProductAssemblyOptionsGroup: FC<Props> = ({
 
   return (
     <Fragment>
-      {assemblyOptionGroup.optin === initiallyOpened ? (
+      {assemblyOptionGroup.optin === false && initiallyOpened === false ? (
         <Button variation="secondary" onClick={changeOptinInput}>
           <IOMessage
             id="store/product-customizer.add-assembly"

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
@@ -10,7 +10,7 @@ import useAssemblyOptionsModifications from '../../modules/useAssemblyOptionsMod
 import { ProductAssemblyItemProvider } from '../ProductAssemblyContext/Item'
 import ProductAssemblyOptionsItem from './ProductAssemblyOptionsItem'
 
-const ProductAssemblyOptionsGroup: FC = ({ children }) => {
+const ProductAssemblyOptionsGroup: FC<AssemblyOptionsGroup> = ({ children, initiallyOpened }) => {
   const assemblyOptionGroup = useProductAssemblyGroupState() as AssemblyOptionGroupState
   const dispatch = useProductAssemblyGroupDispatch()
 
@@ -27,7 +27,7 @@ const ProductAssemblyOptionsGroup: FC = ({ children }) => {
 
   return (
     <Fragment>
-      {assemblyOptionGroup.optin === false ? (
+      {assemblyOptionGroup.optin === initiallyOpened ? (
         <Button variation="secondary" onClick={changeOptinInput}>
           <IOMessage
             id="store/product-customizer.add-assembly"

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
@@ -10,7 +10,7 @@ import useAssemblyOptionsModifications from '../../modules/useAssemblyOptionsMod
 import { ProductAssemblyItemProvider } from '../ProductAssemblyContext/Item'
 import ProductAssemblyOptionsItem from './ProductAssemblyOptionsItem'
 
-const ProductAssemblyOptionsGroup: FC<AssemblyOptionsGroup> = ({ children, initiallyOpened }) => {
+const ProductAssemblyOptionsGroup: FC<AssemblyOptionsGroup> = ({ children, initiallyOpened = false }) => {
   const assemblyOptionGroup = useProductAssemblyGroupState() as AssemblyOptionGroupState
   const dispatch = useProductAssemblyGroupDispatch()
 

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
@@ -10,7 +10,14 @@ import useAssemblyOptionsModifications from '../../modules/useAssemblyOptionsMod
 import { ProductAssemblyItemProvider } from '../ProductAssemblyContext/Item'
 import ProductAssemblyOptionsItem from './ProductAssemblyOptionsItem'
 
-const ProductAssemblyOptionsGroup: FC<AssemblyOptionsGroup> = ({ children, initiallyOpened = false }) => {
+interface Props {
+  initiallyOpened?: boolean
+}
+
+const ProductAssemblyOptionsGroup: FC<Props> = ({
+  children,
+  initiallyOpened = false,
+}) => {
   const assemblyOptionGroup = useProductAssemblyGroupState() as AssemblyOptionGroupState
   const dispatch = useProductAssemblyGroupDispatch()
 

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
@@ -11,12 +11,12 @@ import { ProductAssemblyItemProvider } from '../ProductAssemblyContext/Item'
 import ProductAssemblyOptionsItem from './ProductAssemblyOptionsItem'
 
 interface Props {
-  initiallyOpened?: boolean
+  initiallyOpened?: 'always' | 'required'
 }
 
 const ProductAssemblyOptionsGroup: FC<Props> = ({
   children,
-  initiallyOpened = false,
+  initiallyOpened = 'required',
 }) => {
   const assemblyOptionGroup = useProductAssemblyGroupState() as AssemblyOptionGroupState
   const dispatch = useProductAssemblyGroupDispatch()
@@ -34,7 +34,7 @@ const ProductAssemblyOptionsGroup: FC<Props> = ({
 
   return (
     <Fragment>
-      {assemblyOptionGroup.optin === false && initiallyOpened === false ? (
+      {assemblyOptionGroup.optin === false && initiallyOpened === 'required' ? (
         <Button variation="secondary" onClick={changeOptinInput}>
           <IOMessage
             id="store/product-customizer.add-assembly"

--- a/react/typings/ProjectTypings.d.ts
+++ b/react/typings/ProjectTypings.d.ts
@@ -130,4 +130,8 @@ declare global {
     quantity: number
     children: Record<string, AssemblyOptionGroupState> | null
   }
+
+  interface AssemblyOptionsGroup {
+    initiallyOpened?: boolean
+  }
 }

--- a/react/typings/ProjectTypings.d.ts
+++ b/react/typings/ProjectTypings.d.ts
@@ -130,8 +130,4 @@ declare global {
     quantity: number
     children: Record<string, AssemblyOptionGroupState> | null
   }
-
-  interface AssemblyOptionsGroup {
-    initiallyOpened?: boolean
-  }
 }


### PR DESCRIPTION
#### What problem is this solving?

The customization box opened when the page is loaded so the user doesn't have to click on it to open. 
And if the box is initially closed, some users don't know exactly where they can customize the product

#### How to test it?

You can test in this workspace: https://leo--worldwidegolf.myvtex.com/callaway-supersoft-matte-custom-golf-balls-100007409/p

#### Screenshots or example usage:

Before: https://prnt.sc/tyj6vg

After: https://prnt.sc/tyj75i

#### How does this PR make you feel? [:link:](http://giphy.com/)

https://media.giphy.com/media/MVDPX3gaKFPuo/giphy.gif
