### PR TITLE
Fix assemblies modal to select correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- ModalView customize error
+
 ## [2.9.2] - 2020-11-13
 ### Fixed
 - Subscription labels not being localized.

--- a/react/components/ProductAssemblyContext/Group.tsx
+++ b/react/components/ProductAssemblyContext/Group.tsx
@@ -56,6 +56,7 @@ const initState = (assemblyOption: AssemblyOptionGroupState) => {
     Record<string, string | boolean>
   >((acc, inputValue) => {
     acc[inputValue.label] = inputValue.defaultValue
+
     return acc
   }, {})
 
@@ -87,6 +88,7 @@ function getGroupPath(assemblyTreePath?: TreePath[]) {
   const treePath = assemblyTreePath ?? []
 
   let groupPath: string[] = []
+
   for (const currentPath of treePath) {
     groupPath = groupPath.concat([
       'items',
@@ -135,6 +137,7 @@ function reducer(
 
       return { ...state }
     }
+
     case 'SET_INPUT_VALUE': {
       const { groupPath, inputValue, inputValueLabel } = action.args
       const groupState = getGroupState(state, groupPath)
@@ -143,13 +146,15 @@ function reducer(
 
       return { ...state }
     }
+
     case 'SET_QUANTITY': {
       if (!state.items) {
         return state
       }
 
       const { itemId, newQuantity, type, groupPath } = action.args
-      const groupState = path(groupPath, state) as AssemblyOptionGroup
+      const groupState = (path(groupPath, state) ??
+        state) as AssemblyOptionGroup
 
       if (type === GROUP_TYPES.SINGLE) {
         groupState.items = removeAllItems(groupState.items)
@@ -158,7 +163,9 @@ function reducer(
       const newItems = {
         ...groupState.items,
         ...(itemId && groupState.items && groupState.items[itemId]
-          ? { [itemId]: { ...groupState.items[itemId], quantity: newQuantity } }
+          ? {
+              [itemId]: { ...groupState.items[itemId], quantity: newQuantity },
+            }
           : {}),
       }
 
@@ -172,6 +179,7 @@ function reducer(
 
       return { ...state }
     }
+
     default:
       return state
   }
@@ -184,6 +192,7 @@ function removeAllItems(items: Record<string, AssemblyItem>) {
         ...items[itemId],
         quantity: 0,
       }
+
       return acc
     },
     {}


### PR DESCRIPTION
#### What problem is this solving?

Fix assemblies modal to select correctly. On select some of these options (print 1) we receive a JS error (print 2)

**Print 1**
![image](https://user-images.githubusercontent.com/49173685/100484580-bd7d2b00-30db-11eb-9f63-502cb56943de.png)

**Print 2**
![image](https://user-images.githubusercontent.com/49173685/100484624-f4534100-30db-11eb-8bf6-e5438ad5de0a.png)

#### How to test it?

[Workspace](https://mcdon90--acctglobal.myvtex.com/mcproductrefid136/p)

#### Screenshots or example usage:

**Working correctly:**
![image](https://user-images.githubusercontent.com/49173685/100484675-282e6680-30dc-11eb-866b-fb554eeb2bfa.png)
