### PR TITLE
Fix subscription messages for es and pt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Subscription messages for `es` and `pt` locales.
 
 ## [2.9.2] - 2020-11-13
 ### Fixed

--- a/messages/es.json
+++ b/messages/es.json
@@ -20,10 +20,10 @@
   "store/product-customizer.remove-assembly": "Eliminar",
   "store/product-customizer.subscription": "Suscripción",
   "store/product-customizer.subscription.frequency": "Frecuencia",
-  "store/product-customizer.subscription.frequency.day": "Cada {frequencyNumber, plural, one {# dia} other {# dias}}",
-  "store/product-customizer.subscription.frequency.month": "Cada {frequencyNumber, plural, one {# mes} other {# meses}}",
-  "store/product-customizer.subscription.frequency.week": "Cada {frequencyNumber, plural, one {# semana} other {# semanas}}",
-  "store/product-customizer.subscription.frequency.year": "Cada {frequencyNumber, plural, one {# año} other {# años}}",
+  "store/product-customizer.subscription.frequency.day": "Cada {interval, plural, one {# dia} other {# dias}}",
+  "store/product-customizer.subscription.frequency.month": "Cada {interval, plural, one {# mes} other {# meses}}",
+  "store/product-customizer.subscription.frequency.week": "Cada {interval, plural, one {# semana} other {# semanas}}",
+  "store/product-customizer.subscription.frequency.year": "Cada {interval, plural, one {# año} other {# años}}",
   "store/product-customizer.subscription.purchaseday": "Día de facturación",
   "store/product-customizer.subscription.purchaseday.day": "{day}º dia del mes"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -20,10 +20,10 @@
   "store/product-customizer.remove-assembly": "Remover",
   "store/product-customizer.subscription": "Assinatura",
   "store/product-customizer.subscription.frequency": "Frequência",
-  "store/product-customizer.subscription.frequency.day": "A cada {frequencyNumber, plural, one {# dia} other {# dias}}",
-  "store/product-customizer.subscription.frequency.month": "A cada {frequencyNumber, plural, one {# mês} other {# meses}}",
-  "store/product-customizer.subscription.frequency.week": "A cada {frequencyNumber, plural, one {# semana} other {# semanas}}",
-  "store/product-customizer.subscription.frequency.year": "A cada {frequencyNumber, plural, one {# ano} other {# anos}}",
+  "store/product-customizer.subscription.frequency.day": "A cada {interval, plural, one {# dia} other {# dias}}",
+  "store/product-customizer.subscription.frequency.month": "A cada {interval, plural, one {# mês} other {# meses}}",
+  "store/product-customizer.subscription.frequency.week": "A cada {interval, plural, one {# semana} other {# semanas}}",
+  "store/product-customizer.subscription.frequency.year": "A cada {interval, plural, one {# ano} other {# anos}}",
   "store/product-customizer.subscription.purchaseday": "Dia da compra",
   "store/product-customizer.subscription.purchaseday.day": "{day}º dia do mês"
 }


### PR DESCRIPTION
#### What problem is this solving?

Some messages for the `es` and `pt` locales were using wrong variable names for the interpolation of values.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

Compare 

1) https://storecomponents.myvtex.com/vintage-phone/p

with

2) https://subscustomizer--storecomponents.myvtex.com/vintage-phone/p

Switch the store language from `en` to either `pt  or `es`.


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/67urFpVn7qwcd2gWIl/giphy-downsized.gif)
