### PR TITLE
Fix/hard coded string and portal propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Hard-coded `customize` string replaced with `FormattedMessage`.
+- Prevent events from modal content being propagated to its react-tree parents.
 
 ## [2.9.2] - 2020-11-13
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Hard-coded `customize` string replaced with `FormattedMessage`.
 
 ## [2.9.2] - 2020-11-13
 ### Fixed

--- a/messages/context.json
+++ b/messages/context.json
@@ -25,5 +25,6 @@
   "store/product-customizer.subscription.frequency.month": "Every {interval, plural, one {month} other {# months}}",
   "store/product-customizer.subscription.frequency.week": "Every {interval, plural, one {week} other {# weeks}}",
   "store/product-customizer.subscription.frequency.year": "Every {interval, plural, one {year} other {# years}}",
-  "store/product-customizer.subscription.purchaseday.day": "{day, plural, one {1st} two {2nd} three {3rd} other {#th}} day of the month"
+  "store/product-customizer.subscription.purchaseday.day": "{day, plural, one {1st} two {2nd} three {3rd} other {#th}} day of the month",
+  "store/product-customizer.customize": "Customize"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -25,5 +25,6 @@
   "store/product-customizer.subscription.frequency.week": "Every {interval, plural, one {week} other {# weeks}}",
   "store/product-customizer.subscription.frequency.year": "Every {interval, plural, one {year} other {# years}}",
   "store/product-customizer.subscription.purchaseday": "Purchase day",
-  "store/product-customizer.subscription.purchaseday.day": "{day, plural, =1{1st} =2{2nd} =3{3rd} other {#th}} day of the month"
+  "store/product-customizer.subscription.purchaseday.day": "{day, plural, =1{1st} =2{2nd} =3{3rd} other {#th}} day of the month",
+  "store/product-customizer.customize": "Customize"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -25,5 +25,6 @@
   "store/product-customizer.subscription.frequency.week": "Cada {frequencyNumber, plural, one {# semana} other {# semanas}}",
   "store/product-customizer.subscription.frequency.year": "Cada {frequencyNumber, plural, one {# año} other {# años}}",
   "store/product-customizer.subscription.purchaseday": "Día de facturación",
-  "store/product-customizer.subscription.purchaseday.day": "{day}º dia del mes"
+  "store/product-customizer.subscription.purchaseday.day": "{day}º dia del mes",
+  "store/product-customizer.customize": "Personalizar"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -25,5 +25,6 @@
   "store/product-customizer.subscription.frequency.week": "A cada {frequencyNumber, plural, one {# semana} other {# semanas}}",
   "store/product-customizer.subscription.frequency.year": "A cada {frequencyNumber, plural, one {# ano} other {# anos}}",
   "store/product-customizer.subscription.purchaseday": "Dia da compra",
-  "store/product-customizer.subscription.purchaseday.day": "{day}º dia do mês"
+  "store/product-customizer.subscription.purchaseday.day": "{day}º dia do mês",
+  "store/product-customizer.customize": "Customizar"
 }

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
@@ -2,6 +2,7 @@ import React, { Fragment, useState, FC } from 'react'
 import { Button, Modal } from 'vtex.styleguide'
 import ProductPrice from 'vtex.store-components/ProductPrice'
 import { useDevice } from 'vtex.device-detector'
+import { FormattedMessage } from 'react-intl'
 
 import { useProductAssemblyItem } from '../ProductAssemblyContext/Item'
 import ProductAssemblyOptionsGroup from './ProductAssemblyOptionsGroup'
@@ -102,7 +103,9 @@ const ProductAssemblyOptionItemCustomize: FC<Props> = ({
         collapseLeft={buttonCollapse === 'left'}
         collapseRight={buttonCollapse === 'right'}
       >
-        <div className="c-action-primary t-action">Customize</div>
+        <div className="c-action-primary t-action">
+          <FormattedMessage id="store/product-customizer.customize" />
+        </div>
       </Button>
       <Modal
         isOpen={modalOpen}

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
@@ -9,6 +9,7 @@ import ProductAssemblyOptionsGroup from './ProductAssemblyOptionsGroup'
 import { imageUrlForSize } from './ProductAssemblyOptionItemImage'
 import { ProductAssemblyGroupContextProvider } from '../ProductAssemblyContext/Group'
 import { withItem } from './withItem'
+import StopPropagation from '../StopPropagation'
 
 const IMG_SIZE = 140
 
@@ -107,14 +108,16 @@ const ProductAssemblyOptionItemCustomize: FC<Props> = ({
           <FormattedMessage id="store/product-customizer.customize" />
         </div>
       </Button>
-      <Modal
-        isOpen={modalOpen}
-        onClose={closeAction}
-        centered={!isMobile}
-        title={`Customize your ${name}`}
-      >
-        <ModalView closeAction={closeAction}>{children}</ModalView>
-      </Modal>
+      <StopPropagation>
+        <Modal
+          isOpen={modalOpen}
+          onClose={closeAction}
+          centered={!isMobile}
+          title={`Customize your ${name}`}
+        >
+          <ModalView closeAction={closeAction}>{children}</ModalView>
+        </Modal>
+      </StopPropagation>
     </Fragment>
   )
 }

--- a/react/components/StopPropagation.tsx
+++ b/react/components/StopPropagation.tsx
@@ -1,0 +1,54 @@
+// Why this is needed you ask?
+// See: https://github.com/facebook/react/issues/11387
+
+import React from 'react'
+import type { PropsWithChildren } from 'react'
+
+const stop = (e: Event) => e.stopPropagation()
+
+const eventHandlers = {
+  onClick: stop,
+  onContextMenu: stop,
+  onDoubleClick: stop,
+  onDrag: stop,
+  onDragEnd: stop,
+  onDragEnter: stop,
+  onDragExit: stop,
+  onDragLeave: stop,
+  onDragOver: stop,
+  onDragStart: stop,
+  onDrop: stop,
+  onMouseDown: stop,
+  onMouseEnter: stop,
+  onMouseLeave: stop,
+  onMouseMove: stop,
+  onMouseOver: stop,
+  onMouseOut: stop,
+  onMouseUp: stop,
+
+  onKeyDown: stop,
+  onKeyPress: stop,
+  onKeyUp: stop,
+
+  onFocus: stop,
+  onBlur: stop,
+
+  onChange: stop,
+  onInput: stop,
+  onInvalid: stop,
+  onSubmit: stop,
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+function NoPropagation({ children }: PropsWithChildren<{}>) {
+  return (
+    <>
+      {/* @ts-expect-error Purposedfully stops propagation of all events */}
+      <div {...eventHandlers} style={{ display: 'contents' }}>
+        {children}
+      </div>
+    </>
+  )
+}
+
+export default NoPropagation


### PR DESCRIPTION
#### What problem is this solving?

- Removes the hard-coded `Customize` string in favor of a localized message.
- Prevents any event propagation from a customizer modal's content (see https://github.com/facebook/react/issues/11387)

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

Compare:

https://brassbell.myvtex.com/medium-brass-railroad-bell--polished/p
https://kiwi--brassbell.myvtex.com/medium-brass-railroad-bell--polished/p

By clicking in the first `ADD TEXT`. A modal should open. In the `master` workspace, any click or space keypress inside the modal should check/uncheck the assembly option checkbox.

#### Screenshots or example usage:

n/a

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/XzYmUa1ghSyXR8YRth/giphy-downsized.gif)
