### PR TITLE
Fixing misspelled handle name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Misspelled handle name causing build error
 
 ## [2.10.0] - 2020-12-07
 

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
@@ -133,7 +133,7 @@ const ProductAssemblyOptionItemCustomize: FC<Props> = ({
         {...buttonProps}
       >
         <div
-          className={`${handles.productAssemblyOptionItemCustomize__label} c-action-primary t-action`}
+          className={`${handles.productAssemblyOptionItemCustomizeLabel} c-action-primary t-action`}
         >
           <FormattedMessage id="store/product-customizer.customize" />
         </div>


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes a misspelled handle name causing the app not to build.

#### How to test it?

I've linked the app [on this Workspace](https://icarosearch2--storecomponents.myvtex.com)

#### Related to / Depends on

Related to [product-customizer#75](https://github.com/vtex-apps/product-customizer/pull/75)