### PR TITLE
Add recursive dispatch update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- AssemblyOptions tree deep Items quantities. Update parents of nodes that has been changed.
 
 ## [2.10.2] - 2021-01-13
 

--- a/react/__fixtures__/productHamburguer.json
+++ b/react/__fixtures__/productHamburguer.json
@@ -1,0 +1,1177 @@
+{
+  "data": {
+    "product": {
+      "cacheId": "mcproductrefid136",
+      "productId": "2003666",
+      "description": "Descrição genérica",
+      "productName": "Family Box 1",
+      "productReference": "MCPRODUCTREFID136",
+      "linkText": "mcproductrefid136",
+      "brand": "Test Brand name",
+      "brandId": 2000000,
+      "link": "https://portal.vtexcommercestable.com.br/mcproductrefid136/p",
+      "categories": ["/MACCT/Family Box/", "/MACCT/"],
+      "categoryId": "47",
+      "priceRange": {
+        "sellingPrice": {
+          "highPrice": 11,
+          "lowPrice": 11,
+          "__typename": "PriceRange"
+        },
+        "listPrice": {
+          "highPrice": 11,
+          "lowPrice": 11,
+          "__typename": "PriceRange"
+        },
+        "__typename": "ProductPriceRange"
+      },
+      "specificationGroups": [],
+      "skuSpecifications": null,
+      "productClusters": [],
+      "clusterHighlights": [],
+      "properties": [],
+      "__typename": "Product",
+      "titleTag": "Family Box 1",
+      "metaTagDescription": null,
+      "items": [
+        {
+          "itemId": "10104",
+          "name": "Family Box 1",
+          "nameComplete": "Family Box 1",
+          "complementName": "",
+          "ean": "MCexempleean123469",
+          "variations": [],
+          "referenceId": [
+            {
+              "Key": "RefId",
+              "Value": "MCexemplerefidSKU014",
+              "__typename": "Reference"
+            }
+          ],
+          "measurementUnit": "un",
+          "unitMultiplier": 1,
+          "images": [
+            {
+              "cacheId": "155732",
+              "imageId": "155732",
+              "imageLabel": "",
+              "imageTag": "<img src=\"~/arquivos/ids/155732-#width#-#height#/test-product.jpg?v=637411294577970000\" width=\"#width#\" height=\"#height#\" alt=\"test-product\" id=\"\" />",
+              "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155732/test-product.jpg?v=637411294577970000",
+              "imageText": "test-product",
+              "__typename": "Image"
+            }
+          ],
+          "__typename": "SKU",
+          "videos": [],
+          "sellers": [
+            {
+              "sellerId": "1",
+              "sellerName": "ACCT CONSULTORIA E DESENVOLVIMENTO LTDA",
+              "__typename": "Seller",
+              "addToCartLink": "https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=10104&qty=1&seller=1&sc=1&price=1100&cv=124B4B001C2F62802E0E34F4A0A079EB_&sc=1",
+              "sellerDefault": true,
+              "commertialOffer": {
+                "discountHighlights": [],
+                "teasers": [],
+                "Price": 11,
+                "ListPrice": 11,
+                "Tax": 0,
+                "taxPercentage": 0,
+                "spotPrice": 11,
+                "PriceWithoutDiscount": 11,
+                "RewardValue": 0,
+                "PriceValidUntil": "2022-02-01T18:22:16Z",
+                "AvailableQuantity": 1000000,
+                "__typename": "Offer",
+                "CacheVersionUsedToCallCheckout": "124B4B001C2F62802E0E34F4A0A079EB_",
+                "Installments": [
+                  {
+                    "Value": 11,
+                    "InterestRate": 0,
+                    "TotalValuePlusInterestRate": 11,
+                    "NumberOfInstallments": 1,
+                    "Name": "American Express à vista",
+                    "PaymentSystemName": "American Express",
+                    "__typename": "Installment"
+                  },
+                  {
+                    "Value": 11,
+                    "InterestRate": 0,
+                    "TotalValuePlusInterestRate": 11,
+                    "NumberOfInstallments": 1,
+                    "Name": "Visa à vista",
+                    "PaymentSystemName": "Visa",
+                    "__typename": "Installment"
+                  },
+                  {
+                    "Value": 11,
+                    "InterestRate": 0,
+                    "TotalValuePlusInterestRate": 11,
+                    "NumberOfInstallments": 1,
+                    "Name": "Mastercard à vista",
+                    "PaymentSystemName": "Mastercard",
+                    "__typename": "Installment"
+                  },
+                  {
+                    "Value": 11,
+                    "InterestRate": 0,
+                    "TotalValuePlusInterestRate": 11,
+                    "NumberOfInstallments": 1,
+                    "Name": "Vale à vista",
+                    "PaymentSystemName": "Vale",
+                    "__typename": "Installment"
+                  },
+                  {
+                    "Value": 11,
+                    "InterestRate": 0,
+                    "TotalValuePlusInterestRate": 11,
+                    "NumberOfInstallments": 1,
+                    "Name": "Promissory à vista",
+                    "PaymentSystemName": "Promissory",
+                    "__typename": "Installment"
+                  },
+                  {
+                    "Value": 11,
+                    "InterestRate": 0,
+                    "TotalValuePlusInterestRate": 11,
+                    "NumberOfInstallments": 1,
+                    "Name": "BOLBRADESCO à vista",
+                    "PaymentSystemName": "BOLBRADESCO",
+                    "__typename": "Installment"
+                  }
+                ]
+              }
+            }
+          ],
+          "kitItems": [],
+          "attachments": [
+            {
+              "id": "20",
+              "name": "Family Box - 1",
+              "required": true,
+              "__typename": "Attachment"
+            },
+            {
+              "id": "22",
+              "name": "Side Extra",
+              "required": false,
+              "__typename": "Attachment"
+            }
+          ],
+          "estimatedDateArrival": "2014-03-05T00:00:00"
+        }
+      ],
+      "itemMetadata": {
+        "items": [
+          {
+            "id": "10104",
+            "name": "Family Box 1",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155732/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [
+              {
+                "id": "Side Extra_Acompanhamento Adicional",
+                "name": "Side Extra",
+                "required": false,
+                "inputValues": [],
+                "composition": {
+                  "minQuantity": 0,
+                  "maxQuantity": 10,
+                  "items": [
+                    {
+                      "id": "10106",
+                      "minQuantity": 0,
+                      "maxQuantity": 5,
+                      "priceTable": "mcside",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10107",
+                      "minQuantity": 0,
+                      "maxQuantity": 5,
+                      "priceTable": "mcside",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    }
+                  ],
+                  "__typename": "CompositionType"
+                },
+                "__typename": "AssemblyOption"
+              },
+              {
+                "id": "_Combo2",
+                "name": "Family Box - 1",
+                "required": true,
+                "inputValues": [],
+                "composition": {
+                  "minQuantity": 1,
+                  "maxQuantity": 1,
+                  "items": [
+                    {
+                      "id": "10101",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "mclanches",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10102",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "mclanches",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    }
+                  ],
+                  "__typename": "CompositionType"
+                },
+                "__typename": "AssemblyOption"
+              },
+              {
+                "id": "_Combo1",
+                "name": "Family Box - 1",
+                "required": true,
+                "inputValues": [],
+                "composition": {
+                  "minQuantity": 1,
+                  "maxQuantity": 1,
+                  "items": [
+                    {
+                      "id": "10101",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "mclanches",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10102",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "mclanches",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    }
+                  ],
+                  "__typename": "CompositionType"
+                },
+                "__typename": "AssemblyOption"
+              }
+            ],
+            "__typename": "ItemMetadataUnit"
+          },
+          {
+            "id": "10106",
+            "name": "MACCT Fries",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155734/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [],
+            "__typename": "ItemMetadataUnit"
+          },
+          {
+            "id": "10107",
+            "name": "MACCT Nuggets",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155735/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [],
+            "__typename": "ItemMetadataUnit"
+          },
+          {
+            "id": "10101",
+            "name": "Combo 1",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155729/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [
+              {
+                "id": "Side Extra_Acompanhamento Adicional",
+                "name": "Side Extra",
+                "required": false,
+                "inputValues": [],
+                "composition": {
+                  "minQuantity": 0,
+                  "maxQuantity": 10,
+                  "items": [
+                    {
+                      "id": "10106",
+                      "minQuantity": 0,
+                      "maxQuantity": 5,
+                      "priceTable": "mcside",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10107",
+                      "minQuantity": 0,
+                      "maxQuantity": 5,
+                      "priceTable": "mcside",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    }
+                  ],
+                  "__typename": "CompositionType"
+                },
+                "__typename": "AssemblyOption"
+              },
+              {
+                "id": "Combo 1_Acompanhamento",
+                "name": "Combo 1",
+                "required": true,
+                "inputValues": [],
+                "composition": {
+                  "minQuantity": 1,
+                  "maxQuantity": 1,
+                  "items": [
+                    {
+                      "id": "10106",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "mclanches",
+                      "seller": "1",
+                      "initialQuantity": 1,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10107",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "mclanches",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    }
+                  ],
+                  "__typename": "CompositionType"
+                },
+                "__typename": "AssemblyOption"
+              },
+              {
+                "id": "Combo 1_Bebida",
+                "name": "Combo 1",
+                "required": true,
+                "inputValues": [],
+                "composition": {
+                  "minQuantity": 1,
+                  "maxQuantity": 1,
+                  "items": [
+                    {
+                      "id": "10108",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "mclanches",
+                      "seller": "1",
+                      "initialQuantity": 1,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10109",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "mclanches",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    }
+                  ],
+                  "__typename": "CompositionType"
+                },
+                "__typename": "AssemblyOption"
+              },
+              {
+                "id": "Combo 1_Lanche",
+                "name": "Combo 1",
+                "required": true,
+                "inputValues": [],
+                "composition": {
+                  "minQuantity": 1,
+                  "maxQuantity": 1,
+                  "items": [
+                    {
+                      "id": "10091",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "mclanches",
+                      "seller": "1",
+                      "initialQuantity": 1,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10093",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "mclanches",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    }
+                  ],
+                  "__typename": "CompositionType"
+                },
+                "__typename": "AssemblyOption"
+              }
+            ],
+            "__typename": "ItemMetadataUnit"
+          },
+          {
+            "id": "10108",
+            "name": "Refrigerante 1",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155736/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [],
+            "__typename": "ItemMetadataUnit"
+          },
+          {
+            "id": "10109",
+            "name": "Refrigerante 2",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155737/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [],
+            "__typename": "ItemMetadataUnit"
+          },
+          {
+            "id": "10091",
+            "name": "Big MACCT",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155719/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [
+              {
+                "id": "Extra_Extra",
+                "name": "Extra",
+                "required": false,
+                "inputValues": [],
+                "composition": {
+                  "minQuantity": 0,
+                  "maxQuantity": 4,
+                  "items": [
+                    {
+                      "id": "10110",
+                      "minQuantity": 0,
+                      "maxQuantity": 2,
+                      "priceTable": "mcextras",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10095",
+                      "minQuantity": 0,
+                      "maxQuantity": 2,
+                      "priceTable": "mcextras",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    }
+                  ],
+                  "__typename": "CompositionType"
+                },
+                "__typename": "AssemblyOption"
+              },
+              {
+                "id": "Big MACCT_Lanche",
+                "name": "Big MACCT",
+                "required": true,
+                "inputValues": [],
+                "composition": {
+                  "minQuantity": 2,
+                  "maxQuantity": 7,
+                  "items": [
+                    {
+                      "id": "10094",
+                      "minQuantity": 0,
+                      "maxQuantity": 2,
+                      "priceTable": "mclanches",
+                      "seller": "1",
+                      "initialQuantity": 2,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10095",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "mclanches",
+                      "seller": "1",
+                      "initialQuantity": 1,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10096",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "mclanches",
+                      "seller": "1",
+                      "initialQuantity": 1,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10097",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "mclanches",
+                      "seller": "1",
+                      "initialQuantity": 1,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10098",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "mclanches",
+                      "seller": "1",
+                      "initialQuantity": 1,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10099",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "mclanches",
+                      "seller": "1",
+                      "initialQuantity": 1,
+                      "__typename": "CompositionItem"
+                    }
+                  ],
+                  "__typename": "CompositionType"
+                },
+                "__typename": "AssemblyOption"
+              }
+            ],
+            "__typename": "ItemMetadataUnit"
+          },
+          {
+            "id": "10110",
+            "name": "Bacon",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155738/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [],
+            "__typename": "ItemMetadataUnit"
+          },
+          {
+            "id": "10095",
+            "name": "Picles",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155723/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [],
+            "__typename": "ItemMetadataUnit"
+          },
+          {
+            "id": "10094",
+            "name": "Hamburguer",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155722/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [],
+            "__typename": "ItemMetadataUnit"
+          },
+          {
+            "id": "10096",
+            "name": "Alface",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155724/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [],
+            "__typename": "ItemMetadataUnit"
+          },
+          {
+            "id": "10097",
+            "name": "Tomate",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155725/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [],
+            "__typename": "ItemMetadataUnit"
+          },
+          {
+            "id": "10098",
+            "name": "Cebola",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155726/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [],
+            "__typename": "ItemMetadataUnit"
+          },
+          {
+            "id": "10099",
+            "name": "Molho",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155727/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [],
+            "__typename": "ItemMetadataUnit"
+          },
+          {
+            "id": "10093",
+            "name": "Lanche Genérico",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155721/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [
+              {
+                "id": "Side Extra_Acompanhamento Adicional",
+                "name": "Side Extra",
+                "required": false,
+                "inputValues": [],
+                "composition": {
+                  "minQuantity": 0,
+                  "maxQuantity": 10,
+                  "items": [
+                    {
+                      "id": "10106",
+                      "minQuantity": 0,
+                      "maxQuantity": 5,
+                      "priceTable": "mcside",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10107",
+                      "minQuantity": 0,
+                      "maxQuantity": 5,
+                      "priceTable": "mcside",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    }
+                  ],
+                  "__typename": "CompositionType"
+                },
+                "__typename": "AssemblyOption"
+              },
+              {
+                "id": "Observações Adicionais - Lanche Genérico",
+                "name": "Observações Adicionais - Lanche Genérico",
+                "required": true,
+                "inputValues": [
+                  {
+                    "label": "Sem Cebola Crispy",
+                    "maxLength": null,
+                    "type": "BOOLEAN",
+                    "domain": null,
+                    "defaultValue": false,
+                    "__typename": "InputValue"
+                  },
+                  {
+                    "label": "Sem Molho Barbecue Extra",
+                    "maxLength": null,
+                    "type": "BOOLEAN",
+                    "domain": null,
+                    "defaultValue": false,
+                    "__typename": "InputValue"
+                  },
+                  {
+                    "label": "Sem Bacon",
+                    "maxLength": null,
+                    "type": "BOOLEAN",
+                    "domain": null,
+                    "defaultValue": false,
+                    "__typename": "InputValue"
+                  },
+                  {
+                    "label": "Sem Queijo Emental",
+                    "maxLength": null,
+                    "type": "BOOLEAN",
+                    "domain": null,
+                    "defaultValue": false,
+                    "__typename": "InputValue"
+                  }
+                ],
+                "composition": null,
+                "__typename": "AssemblyOption"
+              },
+              {
+                "id": "Extra_Extra",
+                "name": "Extra",
+                "required": false,
+                "inputValues": [],
+                "composition": {
+                  "minQuantity": 0,
+                  "maxQuantity": 4,
+                  "items": [
+                    {
+                      "id": "10110",
+                      "minQuantity": 0,
+                      "maxQuantity": 2,
+                      "priceTable": "mcextras",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10095",
+                      "minQuantity": 0,
+                      "maxQuantity": 2,
+                      "priceTable": "mcextras",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    }
+                  ],
+                  "__typename": "CompositionType"
+                },
+                "__typename": "AssemblyOption"
+              }
+            ],
+            "__typename": "ItemMetadataUnit"
+          },
+          {
+            "id": "10102",
+            "name": "Combo 2",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155730/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [
+              {
+                "id": "Combo 2_Acompanhamento",
+                "name": "Combo 2",
+                "required": true,
+                "inputValues": [],
+                "composition": {
+                  "minQuantity": 1,
+                  "maxQuantity": 1,
+                  "items": [
+                    {
+                      "id": "10106",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "main",
+                      "seller": "1",
+                      "initialQuantity": 1,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10107",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "main",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    }
+                  ],
+                  "__typename": "CompositionType"
+                },
+                "__typename": "AssemblyOption"
+              },
+              {
+                "id": "Combo 2_Bebida",
+                "name": "Combo 2",
+                "required": true,
+                "inputValues": [],
+                "composition": {
+                  "minQuantity": 1,
+                  "maxQuantity": 1,
+                  "items": [
+                    {
+                      "id": "10108",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "main",
+                      "seller": "1",
+                      "initialQuantity": 1,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10109",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "main",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    }
+                  ],
+                  "__typename": "CompositionType"
+                },
+                "__typename": "AssemblyOption"
+              },
+              {
+                "id": "Combo 2_Lanche",
+                "name": "Combo 2",
+                "required": true,
+                "inputValues": [],
+                "composition": {
+                  "minQuantity": 1,
+                  "maxQuantity": 1,
+                  "items": [
+                    {
+                      "id": "10092",
+                      "minQuantity": 0,
+                      "maxQuantity": 1,
+                      "priceTable": "main",
+                      "seller": "1",
+                      "initialQuantity": 1,
+                      "__typename": "CompositionItem"
+                    }
+                  ],
+                  "__typename": "CompositionType"
+                },
+                "__typename": "AssemblyOption"
+              }
+            ],
+            "__typename": "ItemMetadataUnit"
+          },
+          {
+            "id": "10092",
+            "name": "MACCTicken",
+            "imageUrl": "https://acctglobal.vtexassets.com/arquivos/ids/155720/test-product.jpg",
+            "seller": "1",
+            "assemblyOptions": [
+              {
+                "id": "Side Extra_Acompanhamento Adicional",
+                "name": "Side Extra",
+                "required": false,
+                "inputValues": [],
+                "composition": {
+                  "minQuantity": 0,
+                  "maxQuantity": 10,
+                  "items": [
+                    {
+                      "id": "10106",
+                      "minQuantity": 0,
+                      "maxQuantity": 5,
+                      "priceTable": "mcside",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10107",
+                      "minQuantity": 0,
+                      "maxQuantity": 5,
+                      "priceTable": "mcside",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    }
+                  ],
+                  "__typename": "CompositionType"
+                },
+                "__typename": "AssemblyOption"
+              },
+              {
+                "id": "additionalInfoMACCTicken",
+                "name": "additionalInfoMACCTicken",
+                "required": true,
+                "inputValues": [
+                  {
+                    "label": "Sem Cebola Crispy",
+                    "maxLength": null,
+                    "type": "BOOLEAN",
+                    "domain": null,
+                    "defaultValue": false,
+                    "__typename": "InputValue"
+                  },
+                  {
+                    "label": "Sem Maionese",
+                    "maxLength": null,
+                    "type": "BOOLEAN",
+                    "domain": null,
+                    "defaultValue": false,
+                    "__typename": "InputValue"
+                  },
+                  {
+                    "label": "Sem Alface",
+                    "maxLength": null,
+                    "type": "BOOLEAN",
+                    "domain": null,
+                    "defaultValue": false,
+                    "__typename": "InputValue"
+                  }
+                ],
+                "composition": null,
+                "__typename": "AssemblyOption"
+              },
+              {
+                "id": "Extra_Extra",
+                "name": "Extra",
+                "required": false,
+                "inputValues": [],
+                "composition": {
+                  "minQuantity": 0,
+                  "maxQuantity": 4,
+                  "items": [
+                    {
+                      "id": "10110",
+                      "minQuantity": 0,
+                      "maxQuantity": 2,
+                      "priceTable": "mcextras",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    },
+                    {
+                      "id": "10095",
+                      "minQuantity": 0,
+                      "maxQuantity": 2,
+                      "priceTable": "mcextras",
+                      "seller": "1",
+                      "initialQuantity": 0,
+                      "__typename": "CompositionItem"
+                    }
+                  ],
+                  "__typename": "CompositionType"
+                },
+                "__typename": "AssemblyOption"
+              }
+            ],
+            "__typename": "ItemMetadataUnit"
+          }
+        ],
+        "priceTable": [
+          {
+            "type": "mcside",
+            "values": [
+              {
+                "id": "10106",
+                "assemblyId": "Side Extra_Acompanhamento Adicional",
+                "price": 600,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10107",
+                "assemblyId": "Side Extra_Acompanhamento Adicional",
+                "price": 600,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10106",
+                "assemblyId": "Side Extra_Acompanhamento Adicional",
+                "price": 600,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10107",
+                "assemblyId": "Side Extra_Acompanhamento Adicional",
+                "price": 600,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10106",
+                "assemblyId": "Side Extra_Acompanhamento Adicional",
+                "price": 600,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10107",
+                "assemblyId": "Side Extra_Acompanhamento Adicional",
+                "price": 600,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10106",
+                "assemblyId": "Side Extra_Acompanhamento Adicional",
+                "price": 600,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10107",
+                "assemblyId": "Side Extra_Acompanhamento Adicional",
+                "price": 600,
+                "__typename": "PriceTableItem"
+              }
+            ],
+            "__typename": "ItemPriceTable"
+          },
+          {
+            "type": "mclanches",
+            "values": [
+              {
+                "id": "10101",
+                "assemblyId": "_Combo2",
+                "price": 1100,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10102",
+                "assemblyId": "_Combo2",
+                "price": 1100,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10101",
+                "assemblyId": "_Combo1",
+                "price": 1100,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10102",
+                "assemblyId": "_Combo1",
+                "price": 1100,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10106",
+                "assemblyId": "Combo 1_Acompanhamento",
+                "price": 500,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10107",
+                "assemblyId": "Combo 1_Acompanhamento",
+                "price": 500,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10108",
+                "assemblyId": "Combo 1_Bebida",
+                "price": 1125,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10109",
+                "assemblyId": "Combo 1_Bebida",
+                "price": 1100,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10091",
+                "assemblyId": "Combo 1_Lanche",
+                "price": 2420,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10093",
+                "assemblyId": "Combo 1_Lanche",
+                "price": 1100,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10094",
+                "assemblyId": "Big MACCT_Lanche",
+                "price": 0,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10095",
+                "assemblyId": "Big MACCT_Lanche",
+                "price": null,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10096",
+                "assemblyId": "Big MACCT_Lanche",
+                "price": null,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10097",
+                "assemblyId": "Big MACCT_Lanche",
+                "price": null,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10098",
+                "assemblyId": "Big MACCT_Lanche",
+                "price": null,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10099",
+                "assemblyId": "Big MACCT_Lanche",
+                "price": null,
+                "__typename": "PriceTableItem"
+              }
+            ],
+            "__typename": "ItemPriceTable"
+          },
+          {
+            "type": "mcextras",
+            "values": [
+              {
+                "id": "10110",
+                "assemblyId": "Extra_Extra",
+                "price": 250,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10095",
+                "assemblyId": "Extra_Extra",
+                "price": 200,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10110",
+                "assemblyId": "Extra_Extra",
+                "price": 250,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10095",
+                "assemblyId": "Extra_Extra",
+                "price": 200,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10110",
+                "assemblyId": "Extra_Extra",
+                "price": 250,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10095",
+                "assemblyId": "Extra_Extra",
+                "price": 200,
+                "__typename": "PriceTableItem"
+              }
+            ],
+            "__typename": "ItemPriceTable"
+          },
+          {
+            "type": "main",
+            "values": [
+              {
+                "id": "10106",
+                "assemblyId": "Combo 2_Acompanhamento",
+                "price": 1100,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10107",
+                "assemblyId": "Combo 2_Acompanhamento",
+                "price": 1100,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10108",
+                "assemblyId": "Combo 2_Bebida",
+                "price": 1125,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10109",
+                "assemblyId": "Combo 2_Bebida",
+                "price": 1100,
+                "__typename": "PriceTableItem"
+              },
+              {
+                "id": "10092",
+                "assemblyId": "Combo 2_Lanche",
+                "price": 2750,
+                "__typename": "PriceTableItem"
+              }
+            ],
+            "__typename": "ItemPriceTable"
+          }
+        ],
+        "__typename": "ItemMetadata"
+      },
+      "benefits": [],
+      "categoryTree": [
+        {
+          "id": 41,
+          "name": "MACCT",
+          "href": "/MACCT",
+          "__typename": "Category"
+        },
+        {
+          "id": 47,
+          "name": "Family Box",
+          "href": "/MACCT/Family-Box",
+          "__typename": "Category"
+        }
+      ]
+    }
+  }
+}

--- a/react/components/ProductAssemblyContext/Group.tsx
+++ b/react/components/ProductAssemblyContext/Group.tsx
@@ -44,7 +44,10 @@ type OptinAction = {
 
 type UpdateChildrenAction = {
   type: 'UPDATE_CHILDREN'
-  args: any
+  args:
+    | SetQuantityAction['args']
+    | SetInputValueAction['args']
+    | OptinAction['args']
 }
 
 export const ProductAssemblyDispatchContext = createContext<
@@ -216,6 +219,14 @@ function reducer(
     }
 
     case 'UPDATE_CHILDREN': {
+      if (
+        !('itemId' in action.args) ||
+        !('newQuantity' in action.args) ||
+        !('type' in action.args)
+      ) {
+        return state
+      }
+
       const { itemId, newQuantity, type, groupPath } = action.args
 
       const groupState = (path(groupPath, state) ??

--- a/react/components/ProductAssemblyContext/Group.tsx
+++ b/react/components/ProductAssemblyContext/Group.tsx
@@ -190,11 +190,17 @@ function reducer(
         return state
       }
 
-      const { itemId, newQuantity, groupPath } = action.args
+      const {
+        itemId,
+        newQuantity,
+        type,
+        groupPath,
+      } = action.args as SetQuantityAction['args']
+
       const groupState = (path(groupPath, state) ??
         state) as AssemblyOptionGroup
 
-      if (state.type === GROUP_TYPES.SINGLE) {
+      if (type === GROUP_TYPES.SINGLE) {
         groupState.items = removeAllItems(groupState.items)
       }
 

--- a/react/components/ProductAssemblyContext/Group.tsx
+++ b/react/components/ProductAssemblyContext/Group.tsx
@@ -4,6 +4,7 @@ import React, {
   Dispatch,
   useReducer,
   FC,
+  useCallback,
 } from 'react'
 import { path } from 'ramda'
 
@@ -78,20 +79,25 @@ const initState = (assemblyOption: AssemblyOptionGroupState) => {
   return assemblyOption
 }
 
-const useCreateRecursiveDispatch = ({
+const useRecursiveDispatch = ({
   dispatch,
 }: {
   dispatch: Dispatch<DispatchAction>
 }) => {
   const parentDispatch = useContext(ProductAssemblyDispatchContext)
 
-  return (action: DispatchAction) => {
-    dispatch(action)
-    parentDispatch({
-      type: 'UPDATE_CHILDREN',
-      args: action.args,
-    })
-  }
+  const recursiveDispatch = useCallback(
+    (action: DispatchAction) => {
+      dispatch(action)
+      parentDispatch({
+        type: 'UPDATE_CHILDREN',
+        args: action.args,
+      })
+    },
+    [dispatch, parentDispatch]
+  )
+
+  return recursiveDispatch
 }
 
 export const ProductAssemblyGroupContextProvider: FC<ProductAssemblyGroupContextProviderProps> = ({
@@ -100,7 +106,7 @@ export const ProductAssemblyGroupContextProvider: FC<ProductAssemblyGroupContext
 }) => {
   const [state, dispatch] = useReducer(reducer, assemblyOption, initState)
 
-  const recursiveDispatch = useCreateRecursiveDispatch({
+  const recursiveDispatch = useRecursiveDispatch({
     dispatch,
   })
 

--- a/react/components/ProductAssemblyContext/Group.tsx
+++ b/react/components/ProductAssemblyContext/Group.tsx
@@ -78,27 +78,20 @@ const initState = (assemblyOption: AssemblyOptionGroupState) => {
   return assemblyOption
 }
 
-const createRecursiveDispatch = ({
-  hasParent,
+const useCreateRecursiveDispatch = ({
   dispatch,
 }: {
-  hasParent: boolean
   dispatch: Dispatch<DispatchAction>
 }) => {
-  if (hasParent) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const parentDispatch = useContext(ProductAssemblyDispatchContext)
+  const parentDispatch = useContext(ProductAssemblyDispatchContext)
 
-    return (action: DispatchAction) => {
-      dispatch(action)
-      parentDispatch({
-        type: 'UPDATE_CHILDREN',
-        args: action.args,
-      })
-    }
+  return (action: DispatchAction) => {
+    dispatch(action)
+    parentDispatch({
+      type: 'UPDATE_CHILDREN',
+      args: action.args,
+    })
   }
-
-  return dispatch
 }
 
 export const ProductAssemblyGroupContextProvider: FC<ProductAssemblyGroupContextProviderProps> = ({
@@ -107,8 +100,7 @@ export const ProductAssemblyGroupContextProvider: FC<ProductAssemblyGroupContext
 }) => {
   const [state, dispatch] = useReducer(reducer, assemblyOption, initState)
 
-  const recursiveDispatch = createRecursiveDispatch({
-    hasParent: !!assemblyOption.treePath.length,
+  const recursiveDispatch = useCreateRecursiveDispatch({
     dispatch,
   })
 

--- a/react/components/ProductAssemblyContext/Group.tsx
+++ b/react/components/ProductAssemblyContext/Group.tsx
@@ -227,11 +227,11 @@ function reducer(
         groupState.items = removeAllItems(groupState.items)
       }
 
-      if (groupState.items[itemId]) {
+      if (groupState?.items && groupState.items[itemId]) {
         groupState.items[itemId].quantity = newQuantity
       }
 
-      const newQuantitySum = Object.values(groupState.items).reduce(
+      const newQuantitySum = Object.values(groupState?.items ?? {}).reduce(
         (acc, { quantity }) => acc + quantity,
         0
       )

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionInputValues.test.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionInputValues.test.tsx
@@ -176,7 +176,7 @@ test('should keep input values for recursive assemblies', async () => {
 
   fireEvent.change(input, { target: { value: 'Foobar' } })
 
-  expect(mockedDispatch.mock.calls).toHaveLength(9)
+  expect(mockedDispatch.mock.calls).toHaveLength(7)
   // eslint-disable-next-line prefer-destructuring
   const [lastCall] = mockedDispatch.mock.calls[5]
 

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionInputValues.test.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionInputValues.test.tsx
@@ -19,6 +19,7 @@ import ProductAssemblyOptionItemQuantity from './ProductAssemblyOptionItemQuanti
 const mockedUseProductDispatch = useProductDispatch as jest.Mock<
   () => jest.Mock
 >
+
 const mockUseProduct = useProduct as jest.Mock<ProductContext>
 
 function renderComponent(customProps = {}) {
@@ -37,6 +38,7 @@ mockUseProduct.mockImplementation(() => ({
 }))
 
 let mockedDispatch = jest.fn()
+
 beforeEach(() => {
   mockedDispatch = jest.fn()
   mockedUseProductDispatch.mockImplementation(() => mockedDispatch)
@@ -46,6 +48,7 @@ test('should handle Options input value', () => {
   const { getByLabelText } = renderComponent()
 
   const font = getByLabelText(/Font/) as HTMLSelectElement
+
   fireEvent.change(font, { target: { value: 'Roman' } })
 
   expect(font.value).toBe('Roman')
@@ -55,6 +58,7 @@ test('should handle Text input value', () => {
   const { getByLabelText } = renderComponent()
 
   const frontText = getByLabelText(/Front text/) as HTMLInputElement
+
   fireEvent.change(frontText, { target: { value: 'Foobar' } })
 
   expect(frontText.value).toBe('Foobar')
@@ -64,6 +68,7 @@ test('should handle Boolean input value', () => {
   const { getByLabelText } = renderComponent()
 
   const glossyPrint = getByLabelText(/Glossy print/) as HTMLInputElement
+
   fireEvent.click(glossyPrint)
 
   expect(glossyPrint.checked).toBe(false)
@@ -75,10 +80,12 @@ test('should show other type of options', () => {
   getByText(/Sans serif/)
 
   const romanOption = getByText(/Roman/)
+
   fireEvent.click(romanOption)
 
   const lastCall =
     mockedDispatch.mock.calls[mockedDispatch.mock.calls.length - 1]
+
   expect(lastCall[0].args.groupInputValues.Font).toBe('Roman')
 })
 
@@ -86,6 +93,7 @@ test('should trigger changes to Product Context', () => {
   const { getByLabelText } = renderComponent()
 
   const font = getByLabelText(/Font/) as HTMLSelectElement
+
   fireEvent.change(font, { target: { value: 'Roman' } })
 
   expect(mockedDispatch.mock.calls[0][0].args.groupInputValues.Font).toBe(
@@ -102,8 +110,10 @@ test('should trigger changes to Product Context', () => {
   ).toBe(true)
 
   const frontText = getByLabelText(/Front text/) as HTMLInputElement
+
   fireEvent.change(frontText, { target: { value: 'Foobar' } })
   const glossyPrint = getByLabelText(/Glossy print/) as HTMLInputElement
+
   fireEvent.click(glossyPrint)
 
   expect(mockedDispatch.mock.calls).toHaveLength(4)
@@ -149,22 +159,27 @@ test('should keep input values for recursive assemblies', async () => {
   const customizeButton = assembly.parentElement?.querySelector(
     '.vtex-button'
   ) as HTMLElement
+
   fireEvent.click(customizeButton)
 
   // Click on Add 1-3-lines inside the modal
   const modal = within(
     document.querySelector('.vtex-modal__modal') as HTMLElement
   )
+
   const modalCustomizeButton = modal.getByText('Add 1-3-lines')
+
   fireEvent.click(modalCustomizeButton)
 
   // Type "Foobar" in the Input Value "Line 1"
   const input = modal.getByLabelText('Line 1')
+
   fireEvent.change(input, { target: { value: 'Foobar' } })
 
-  expect(mockedDispatch.mock.calls).toHaveLength(7)
+  expect(mockedDispatch.mock.calls).toHaveLength(9)
   // eslint-disable-next-line prefer-destructuring
   const [lastCall] = mockedDispatch.mock.calls[5]
+
   expect(lastCall.type).toBe('SET_ASSEMBLY_OPTIONS')
   expect(lastCall.args.groupInputValues['Line 1']).toBe('Foobar')
 
@@ -183,6 +198,7 @@ test('should keep input values for recursive assemblies', async () => {
 
   // Check if input still set with "Foobar" previously typed
   const inputLine1 = getByLabelText('Line 1') as HTMLInputElement
+
   expect(inputLine1.value).toBe('Foobar')
 })
 

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemQuantity.test.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemQuantity.test.tsx
@@ -1,19 +1,47 @@
 import React from 'react'
 import { render, fireEvent } from '@vtex/test-tools/react'
 import useProduct, { ProductContext } from 'vtex.product-context/useProduct'
+import { useProductDispatch } from 'vtex.product-context/ProductDispatchContext'
 
 import ProductAssemblyOptions from '../../ProductAssemblyOptions'
 import productPizza from '../../__fixtures__/productPizza.json'
+import productHamburguer from '../../__fixtures__/productHamburguer.json'
 import ProductAssemblyOptionItemName from './ProductAssemblyOptionItemName'
 import ProductAssemblyOptionItemQuantity from './ProductAssemblyOptionItemQuantity'
+import ProductAssemblyOptionItemCustomize from '../../ProductAssemblyOptionItemCustomize'
 
 const mockUseProduct = useProduct as jest.Mock<ProductContext>
+const mockedUseProductDispatch = useProductDispatch as jest.Mock<
+  () => jest.Mock
+>
+
+let mockedDispatch = jest.fn()
+
+beforeEach(() => {
+  mockedDispatch = jest.fn()
+  mockedUseProductDispatch.mockImplementation(() => mockedDispatch)
+  mockUseProduct.mockReset()
+})
+
+const ItemNameAndQuantity = () => (
+  <>
+    <ProductAssemblyOptionItemName />
+    <ProductAssemblyOptionItemQuantity />
+  </>
+)
 
 function renderComponent() {
   return render(
     <ProductAssemblyOptions>
-      <ProductAssemblyOptionItemName />
-      <ProductAssemblyOptionItemQuantity />
+      <ItemNameAndQuantity />
+
+      <ProductAssemblyOptionItemCustomize>
+        <ItemNameAndQuantity />
+
+        <ProductAssemblyOptionItemCustomize>
+          <ItemNameAndQuantity />
+        </ProductAssemblyOptionItemCustomize>
+      </ProductAssemblyOptionItemCustomize>
     </ProductAssemblyOptions>
   )
 }
@@ -31,6 +59,10 @@ function queryQuantityIncreaseButton(
   return container.querySelector(
     `[data-testid="multipleItemQuantitySelector-${itemId}"] [aria-label="+"]`
   ) as HTMLButtonElement
+}
+
+function getLastMockedDispatchArgs(dispatch: jest.Mock) {
+  return dispatch.mock.calls[dispatch.mock.calls.length - 1][0].args
 }
 
 test('should allow changing quantity respecting the min and max quantity', () => {
@@ -52,6 +84,7 @@ test('should allow changing quantity respecting the min and max quantity', () =>
 
   // Check if increase button is enable to go back to 2
   const colaIncreaseButton = queryQuantityIncreaseButton(container, colaId)!
+
   expect(colaIncreaseButton.disabled).toBeFalsy()
 
   // Should also be able to increase another item
@@ -59,13 +92,77 @@ test('should allow changing quantity respecting the min and max quantity', () =>
     container,
     colaDietId
   )!
+
   expect(colaDietIncreaseButton.disabled).toBeFalsy()
 
   // Increase Cola Diet to quantity 1
   const colaDietQuantityInput = queryQuantityInput(container, colaDietId)!
+
   fireEvent.change(colaDietQuantityInput, { target: { value: '1' } })
 
   // Make sure you can't add more quantity of any item
   expect(colaIncreaseButton.disabled).toBeTruthy()
   expect(colaDietIncreaseButton.disabled).toBeTruthy()
+})
+
+test('Check deep assembly options quantity', () => {
+  window.scroll = () => {}
+  mockUseProduct.mockImplementation(() => ({
+    product: productHamburguer.data.product,
+    selectedItem: productHamburguer.data.product.items[0],
+    selectedQuantity: 1,
+  }))
+
+  const { getAllByText, getByText, getAllByLabelText } = renderComponent()
+
+  const [sndComboOneCustomize, _, fstComboOneCustomize] = getAllByText(
+    'Customize'
+  )
+
+  // Open combo2combo1 customization to select lanche generico
+  fireEvent.click(sndComboOneCustomize)
+  // Select lanche generico
+  fireEvent.click(getAllByText('Lanche Genérico')[0])
+  fireEvent.click(getByText('Done'))
+
+  const mockedDispatchCallsFirstLength = mockedDispatch.mock.calls.length
+  const [combo2Combo1] = getLastMockedDispatchArgs(mockedDispatch).groupItems
+
+  // Expect Combo2-Combo1 to be selected
+  expect(combo2Combo1.quantity).toBe(1)
+  // Check if Lanche Generico is selected and Big Macct isn't
+  expect(combo2Combo1.children['Combo 1_Lanche'][1].quantity).toBe(1)
+  expect(combo2Combo1.children['Combo 1_Lanche'][0].quantity).toBe(0)
+
+  // ------ TEST COMBO 1 COMBO 1
+  // Open combo1combo1 customization to select lanche generico
+  fireEvent.click(fstComboOneCustomize)
+  // Select lanche generico
+  fireEvent.click(getAllByText('Lanche Genérico')[1])
+
+  const [combo1Combo1] = getLastMockedDispatchArgs(mockedDispatch).groupItems
+
+  // Expect Combo1-Combo1 to be selected
+  expect(combo1Combo1.quantity).toBe(1)
+  // Check if Lanche Generico is selected and Big Macct isn't
+  expect(combo1Combo1.children['Combo 1_Lanche'][1].quantity).toBe(1)
+  expect(combo1Combo1.children['Combo 1_Lanche'][0].quantity).toBe(0)
+
+  // Assure that dispatch is called
+  expect(mockedDispatch.mock.calls).not.toHaveLength(
+    mockedDispatchCallsFirstLength
+  )
+
+  // Check deepest child test -> Combo 2 -> Combo 1 -> Lanche Genérico -> Bacon
+  const lancheGenericoCustomize = getAllByText('Customize')[5]
+
+  fireEvent.click(lancheGenericoCustomize)
+  fireEvent.click(getByText('Add Extra'))
+  fireEvent.click(getAllByLabelText('+')[0])
+  const combo2Combo1Extra = getLastMockedDispatchArgs(mockedDispatch)
+    .groupItems[0].children['Combo 1_Lanche'][1].children.Extra_Extra
+
+  expect(combo2Combo1Extra[0].initialQuantity).toBe(0)
+  expect(combo2Combo1Extra[0].quantity).toBe(1)
+  expect(combo2Combo1Extra[1].quantity).toBe(0)
 })


### PR DESCRIPTION
#### What problem is this solving?
Fix the `assemblyOption` structure that is passed to addToCart query. 

#### How to test it?
[Workspace](https://brasileirovtex--acctglobal.myvtex.com/mcproductrefid136/p)

**Test 1**
1. Go into workspace
2. Click to customize combo 1
3. Select `Lanche Genérico`
4. Repeat steps 2 and 3 to the other assembly option
5. Click to add product to cart
6. Look at minicart if `Lanche Generico` appears

**Test 2**
1. Go into workspace
2. Click to customize combo 1
3. Select `Lanche Genérico`
4. Repeat steps 2 and 3 to the other assembly option
5. Click to add product to cart
6. Look at minicart if `Lanche Generico` appears
7. Customize `Lanche Generico` adding some extras values


#### Screenshots or example usage:

**After**:
![image](https://user-images.githubusercontent.com/15680320/106316337-4edb5b80-624b-11eb-9b03-8e0237c466ce.png)

**Before**: Pay attention that you've chosen `Lanche Genérico` not the `Big MActt`
![image](https://user-images.githubusercontent.com/15680320/106316465-8a762580-624b-11eb-9571-9fdc9b9fed06.png)


#### Describe alternatives you've considered, if any.
Change the way that add-cart-to-button create the variables to addToCart mutation, look this PR https://github.com/vtex-apps/add-to-cart-button/pull/61

#### Related to / Depends on
-

#### How does this PR make you feel? [:link:](http://giphy.com/)
![](https://media.giphy.com/media/L0Z4qwdwv62cn4haFp/giphy.gif)
