### PR TITLE
Fix getGroupType return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- getGroupType to return type `SINGLE` only when min and max quantity is 1
 
 ## [2.10.4] - 2021-03-08
 

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionInputValues.test.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionInputValues.test.tsx
@@ -222,7 +222,9 @@ test('should select option when click in customize', () => {
   )
 
   const checkStyleguideCheckboxChecked = (container: HTMLElement) => {
-    const radioButton = container.querySelector('.fake-radio') as HTMLElement
+    const radioButton = container.querySelector(
+      '.vtex-checkbox__inner-container'
+    ) as HTMLElement
 
     const classList = Array.from(radioButton.classList)
 

--- a/react/modules/assemblyGroupType.test.ts
+++ b/react/modules/assemblyGroupType.test.ts
@@ -1,0 +1,54 @@
+import { getGroupType, GROUP_TYPES } from './assemblyGroupType'
+
+test('getGroupType should return type single', () => {
+  const fakeAssemblyOptionGroup = {
+    composition: {
+      minQuantity: 1,
+      maxQuantity: 1,
+    },
+  } as AssemblyOption
+
+  expect(getGroupType(fakeAssemblyOptionGroup)).toBe(GROUP_TYPES.SINGLE)
+})
+
+test('getGroupType should return type toggle', () => {
+  const fakeAssemblyOptionGroup = {
+    composition: {
+      minQuantity: 0,
+      maxQuantity: 1,
+      items: [
+        {
+          minQuantity: 0,
+          maxQuantity: 1,
+        },
+        {
+          minQuantity: 0,
+          maxQuantity: 1,
+        },
+      ],
+    },
+  } as AssemblyOption
+
+  expect(getGroupType(fakeAssemblyOptionGroup)).toBe(GROUP_TYPES.TOGGLE)
+})
+
+test('getGroupType should return type multiple', () => {
+  const fakeAssemblyOptionGroup = {
+    composition: {
+      minQuantity: 0,
+      maxQuantity: 1,
+      items: [
+        {
+          minQuantity: 0,
+          maxQuantity: 1,
+        },
+        {
+          minQuantity: 0,
+          maxQuantity: 2, // this value will make the getGroupType return type multiple
+        },
+      ],
+    },
+  } as AssemblyOption
+
+  expect(getGroupType(fakeAssemblyOptionGroup)).toBe(GROUP_TYPES.MULTIPLE)
+})

--- a/react/modules/assemblyGroupType.ts
+++ b/react/modules/assemblyGroupType.ts
@@ -9,15 +9,14 @@ export const GROUP_TYPES: Record<string, GroupTypes> = {
 }
 
 export const getGroupType = (assemblyOption: AssemblyOption): GroupTypes => {
-  if (!assemblyOption.composition) {
-    return GROUP_TYPES.MULTIPLE
-  }
+  const compositionMinQuantity = assemblyOption.composition?.minQuantity ?? 0
+  const compositionMaxQuantity = assemblyOption.composition?.maxQuantity ?? 0
 
-  if (assemblyOption.composition.maxQuantity === 1) {
+  if (compositionMinQuantity === 1 && compositionMaxQuantity === 1) {
     return GROUP_TYPES.SINGLE
   }
 
-  if (assemblyOption.composition.items.every(maxIsOne)) {
+  if (assemblyOption.composition?.items.every(maxIsOne)) {
     return GROUP_TYPES.TOGGLE
   }
 


### PR DESCRIPTION
#### What problem is this solving?
getGroupType return type SINGLE when an assemblyOption has minQuantity = 0 and maxQuantity = 1, but the right value should be type TOGGLE.

#### How to test it?
Everything should maintain the same behavior
[Workspace after change on ACCTGlobal](https://brasileirovtex--acctglobal.myvtex.com/mcproductrefid136/p)
[Workspace before change on ACCTGlobal](https://acctglobal.myvtex.com/mcproductrefid136/p)

In this [workspace](https://brasileiro--storecomponents.myvtex.com/custom-bell/p?skuId=2000585):
1. click on `Add Optional ADD ON`
2. See the checkbox

Obs.: If you compare this change with the master workspace you will see that `Engraving` items changed from radio to checkbox, because the assembly has minQuantity = 0 and maxQuantity = 1.

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
![image](https://user-images.githubusercontent.com/15680320/113333266-97210380-92f8-11eb-8021-19319dcbbd7a.png)


#### Describe alternatives you've considered, if any.

#### Related to / Depends on

#### How does this PR make you feel? [:link:](http://giphy.com/)
Confused 🤯 