### PR TITLE
Trimming frequency in subscriptions when match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Preventing `frequency` from `subscriptions` with whitespaces on the edges with `trim()` 
 ## [2.10.5] - 2021-04-01
 ### Fixed
 - getGroupType to return type `SINGLE` only when min and max quantity is 1

--- a/react/modules/subscriptions.ts
+++ b/react/modules/subscriptions.ts
@@ -67,7 +67,7 @@ export function parseFrequency(
 ): SubscriptionFrequency | undefined {
   if (frequency == null) return
 
-  const match = frequency.match(FREQUENCY_PATTERN)
+  const match = frequency.trim().match(FREQUENCY_PATTERN)
 
   if (!match) {
     return


### PR DESCRIPTION
#### What problem is this solving?

Frequency in subscriptions being inserted with extra whitespaces
![image](https://user-images.githubusercontent.com/13649073/114420091-6491c900-9b8a-11eb-95f8-9410bea7c6f7.png)

#### How to test it?

Click in "Adicionar Assinatura" button

After: [Workspace](https://baseteste--tfcov3.myvtex.com/gaze-tipo-queijo-1811/p?skuId=99)

#### Screenshots or example usage:

Expected result:

![image](https://user-images.githubusercontent.com/13649073/114420182-7c694d00-9b8a-11eb-99a4-641d65aa7310.png)

#### Describe alternatives you've considered, if any.

Also solve it in Catalogue's side

#### How does this PR make you feel? [:link:](http://giphy.com/)
"trim trim" (horrible, I know)
<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/l2SpRS1UqnNzV8Nr2/giphy.gif)
