### PR TITLE
Bug fix/adding handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Aded
+- CSS class handles to the ProductAssemblyOptions InputValues OptionBox
 
 ## [2.11.2] - 2021-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Aded
+### Added
 - CSS class handles to the ProductAssemblyOptions InputValues OptionBox
 
 ## [2.11.2] - 2021-09-30

--- a/docs/README.md
+++ b/docs/README.md
@@ -153,6 +153,9 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `productAssemblyOptionItemImage` |
 | `productAssemblyOptionItemName` |
 | `textInputValue` |
+| `inputValueOptionBoxItem` |
+| `inputValueOptionBoxItemActive` |
+| `inputValueOptionBoxLabel` |
 
 <!-- DOCS-IGNORE:start -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -154,7 +154,6 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `productAssemblyOptionItemName` |
 | `textInputValue` |
 | `inputValueOptionBoxItem` |
-| `inputValueOptionBoxItemActive` |
 | `inputValueOptionBoxLabel` |
 
 <!-- DOCS-IGNORE:start -->

--- a/react/components/ProductAssemblyOptions/InputValue/OptionBox.tsx
+++ b/react/components/ProductAssemblyOptions/InputValue/OptionBox.tsx
@@ -5,7 +5,7 @@ import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import slugify from '../../../modules/slugify'
 import styles from '../styles.css'
 
-const CSS_HANDLES = ['inputValueOptionBox', 'inputValueOptionBoxItem', 'inputValueOptionBoxItemActive'] as const
+const CSS_HANDLES = ['inputValueOptionBox', 'inputValueOptionBoxItem', 'inputValueOptionBoxItemActive', 'inputValueOptionBoxLabel'] as const
 
 const OptionBox: FC<Props> = ({ option, selected, onClick, onKeyDown }) => {
   const handles = useCssHandles(CSS_HANDLES)
@@ -40,7 +40,7 @@ const OptionBox: FC<Props> = ({ option, selected, onClick, onKeyDown }) => {
           }
         )}
       >
-        <div className="c-on-base center pv3 ph5 z-1 t-body">{option}</div>
+        <div className= {`${handles.inputValueOptionBoxLabel} c-on-base center pv3 ph5 z-1 t-body`}>{option}</div>
       </div>
     </div>
   )

--- a/react/components/ProductAssemblyOptions/InputValue/OptionBox.tsx
+++ b/react/components/ProductAssemblyOptions/InputValue/OptionBox.tsx
@@ -5,7 +5,7 @@ import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import slugify from '../../../modules/slugify'
 import styles from '../styles.css'
 
-const CSS_HANDLES = ['inputValueOptionBox'] as const
+const CSS_HANDLES = ['inputValueOptionBox', 'inputValueOptionBoxItem', 'inputValueOptionBoxItemActive'] as const
 
 const OptionBox: FC<Props> = ({ option, selected, onClick, onKeyDown }) => {
   const handles = useCssHandles(CSS_HANDLES)
@@ -32,6 +32,8 @@ const OptionBox: FC<Props> = ({ option, selected, onClick, onKeyDown }) => {
       />
       <div
         className={classNames(
+          handles.inputValueOptionBoxItem,
+          selected ? handles.inputValueOptionBoxItemActive : '' ,
           'w-100 h-100 ba br2 bw1 b--muted-4 z-1 c-muted-5 flex items-center overflow-hidden',
           {
             'hover-b--muted-2': !selected,

--- a/react/components/ProductAssemblyOptions/InputValue/OptionBox.tsx
+++ b/react/components/ProductAssemblyOptions/InputValue/OptionBox.tsx
@@ -5,7 +5,7 @@ import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import slugify from '../../../modules/slugify'
 import styles from '../styles.css'
 
-const CSS_HANDLES = ['inputValueOptionBox', 'inputValueOptionBoxItem', 'inputValueOptionBoxItemActive', 'inputValueOptionBoxLabel'] as const
+const CSS_HANDLES = ['inputValueOptionBox', 'inputValueOptionBoxItem', 'inputValueOptionBoxLabel'] as const
 
 const OptionBox: FC<Props> = ({ option, selected, onClick, onKeyDown }) => {
   const handles = useCssHandles(CSS_HANDLES)
@@ -32,8 +32,7 @@ const OptionBox: FC<Props> = ({ option, selected, onClick, onKeyDown }) => {
       />
       <div
         className={classNames(
-          handles.inputValueOptionBoxItem,
-          selected ? handles.inputValueOptionBoxItemActive : '' ,
+          applyModifiers(handles.inputValueOptionBoxItem,  selected ? 'active' : ""),
           'w-100 h-100 ba br2 bw1 b--muted-4 z-1 c-muted-5 flex items-center overflow-hidden',
           {
             'hover-b--muted-2': !selected,

--- a/react/components/ProductAssemblyOptions/InputValue/OptionBox.tsx
+++ b/react/components/ProductAssemblyOptions/InputValue/OptionBox.tsx
@@ -6,9 +6,9 @@ import slugify from '../../../modules/slugify'
 import styles from '../styles.css'
 
 const CSS_HANDLES = [
-  'inputValueOptionBox', 
-  'inputValueOptionBoxItem', 
-  'inputValueOptionBoxLabel'
+  'inputValueOptionBox',
+  'inputValueOptionBoxItem',
+  'inputValueOptionBoxLabel',
 ] as const
 
 const OptionBox: FC<Props> = ({ option, selected, onClick, onKeyDown }) => {
@@ -37,7 +37,7 @@ const OptionBox: FC<Props> = ({ option, selected, onClick, onKeyDown }) => {
       <div
         className={classNames(
           applyModifiers(
-            handles.inputValueOptionBoxItem,  
+            handles.inputValueOptionBoxItem,
             selected ? 'active' : ''
           ),
           'w-100 h-100 ba br2 bw1 b--muted-4 z-1 c-muted-5 flex items-center overflow-hidden',
@@ -46,8 +46,8 @@ const OptionBox: FC<Props> = ({ option, selected, onClick, onKeyDown }) => {
           }
         )}
       >
-        <div 
-          className= {`${handles.inputValueOptionBoxLabel} c-on-base center pv3 ph5 z-1 t-body`}
+        <div
+          className={`${handles.inputValueOptionBoxLabel} c-on-base center pv3 ph5 z-1 t-body`}
         >
           {option}
         </div>

--- a/react/components/ProductAssemblyOptions/InputValue/OptionBox.tsx
+++ b/react/components/ProductAssemblyOptions/InputValue/OptionBox.tsx
@@ -5,7 +5,11 @@ import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import slugify from '../../../modules/slugify'
 import styles from '../styles.css'
 
-const CSS_HANDLES = ['inputValueOptionBox', 'inputValueOptionBoxItem', 'inputValueOptionBoxLabel'] as const
+const CSS_HANDLES = [
+  'inputValueOptionBox', 
+  'inputValueOptionBoxItem', 
+  'inputValueOptionBoxLabel'
+] as const
 
 const OptionBox: FC<Props> = ({ option, selected, onClick, onKeyDown }) => {
   const handles = useCssHandles(CSS_HANDLES)
@@ -32,14 +36,21 @@ const OptionBox: FC<Props> = ({ option, selected, onClick, onKeyDown }) => {
       />
       <div
         className={classNames(
-          applyModifiers(handles.inputValueOptionBoxItem,  selected ? 'active' : ""),
+          applyModifiers(
+            handles.inputValueOptionBoxItem,  
+            selected ? 'active' : ''
+          ),
           'w-100 h-100 ba br2 bw1 b--muted-4 z-1 c-muted-5 flex items-center overflow-hidden',
           {
             'hover-b--muted-2': !selected,
           }
         )}
       >
-        <div className= {`${handles.inputValueOptionBoxLabel} c-on-base center pv3 ph5 z-1 t-body`}>{option}</div>
+        <div 
+          className= {`${handles.inputValueOptionBoxLabel} c-on-base center pv3 ph5 z-1 t-body`}
+        >
+          {option}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
#### What problem is this solving?

I needed some css handles. I had to stylize the option boxes with a background-color a border radius and I didn't have handles on second div children of  inputValueOptionBox div.  Also I added a handle when one box is selected.

#### How to test it?

https://product--floriaro.myvtex.com/ancora-de-pamant-pentru-troliere-ro/p
it's about those option boxes in the right main column of the product page. 


#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/65282860/116368783-5e018380-a811-11eb-8167-4cdccbf36a8d.png)


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
