### PR TITLE
Update README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- prop `initiallyOpened` to the block `product-assembly-options`.
 
 ## [2.11.0] - 2021-04-22
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,11 +82,16 @@ Now, you are able to use all blocks exported by the `product-customizer` app. Ch
   }
 ```
 
-### `assembly-option-input-values` props
+### `product-assembly-options` props
 
 | Prop name | Type | Description | Default value |
 |--------------|--------|--------------| --------|
 | `initiallyOpened` | `enum` | By default, the customization box is opened if the attachment is required and closed if it's not. You can override this behavior by setting this prop to `always`, making it be opened even if the attachment is not required. Leave it as `required` for the default behavior. | `required` |
+
+### `assembly-option-input-values` props
+
+| Prop name | Type | Description | Default value |
+|--------------|--------|--------------| --------|
 | `optionsDisplay` | `enum` | Define whether the attachment's pre-defined options will be displayed to be selected in a Checkbox (`box`) or in a dropdown list (`select`) . | `select` |
 
 ### `assembly-option-item-customize`props

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,16 +70,15 @@ Now, you are able to use all blocks exported by the `product-customizer` app. Ch
 4. Declare the blocks' props according to the desired scenario. For example:
 
 ```json
-  "product-assembly-options": {
-    "children": [
-      "assembly-option-input-values"
+ "product-assembly-options": {
+ "props":{
+   "initiallyOpened": "always"
+  },
+ "children": [
+   "flex-layout.row#product-assembly-options",
+   "assembly-option-input-values"
     ]
   },
-  "assembly-option-input-values": {
-    "props": {
-      "optionsDisplay": "box"
-    }
-  }
 ```
 
 ### `product-assembly-options` props


### PR DESCRIPTION
#### What problem is this solving?

prop `initiallyOpened` to the block `product-assembly-options`.

The doc describes that the prop `initiallyOpened` is part of `assembly-options-input-values`. However, it is from the `product-assembly-options`.
The right way to declare is:
```
"product-assembly-options": {
 "props":{
   "initiallyOpened": "always"
  }
```

Related information: https://vtexhelp.zendesk.com/agent/tickets/333362