### PR TITLE
Stop click propagation when input has values to avoid unchecking accidentally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Stop click propagation when input has values to avoid unchecking accidentally
+
 ## [2.11.3] - 2022-07-19
 
 ### Fixed

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
@@ -99,7 +99,7 @@ interface ButtonProps {
 
 const hasValues = (itemChildren: any) => {
   const [name] = Object.getOwnPropertyNames(itemChildren)
-  const inputs = itemChildren[name].inputValues
+  const inputs = itemChildren[name]?.inputValues
 
   if (!itemChildren[name]?.valuesOfInputValues) {
     return false

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
@@ -105,9 +105,12 @@ const hasValues = (itemChildren: any) => {
     return false
   }
 
-  return inputs.findIndex((input: { label: string }) => {
+  return inputs.findIndex((
+      input: { label: string }
+    ) => {
     return itemChildren[name].valuesOfInputValues[input.label] !== ''
-  }) !== -1
+  }) 
+  !== -1
 }
 
 const ProductAssemblyOptionItemCustomize: FC<Props> = ({

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
@@ -97,6 +97,19 @@ interface ButtonProps {
   collapse?: 'left' | 'right' | 'none'
 }
 
+const hasValues = (itemChildren: any) => {
+  const [name] = Object.getOwnPropertyNames(itemChildren)
+  const inputs = itemChildren[name].inputValues
+
+  if (!itemChildren[name]?.valuesOfInputValues) {
+    return false
+  }
+
+  return inputs.findIndex((input: { label: string }) => {
+    return itemChildren[name].valuesOfInputValues[input.label] !== ''
+  }) !== -1
+}
+
 const ProductAssemblyOptionItemCustomize: FC<Props> = ({
   children,
   buttonProps = {},
@@ -117,7 +130,10 @@ const ProductAssemblyOptionItemCustomize: FC<Props> = ({
     return null
   }
 
-  const handleClick = () => {
+  const handleClick = (e: any) => {
+    if(hasValues(itemChildren)) {
+      e.stopPropagation()
+    }
     setModalOpen(true)
   }
 

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
@@ -90,7 +90,7 @@ const ModalView: FC<{ closeAction: () => void }> = ({
 
 interface Props {
   buttonProps?: ButtonProps
-  modalProps?: unknown
+  modalProps?: any
 }
 
 interface ButtonProps {
@@ -105,14 +105,11 @@ const hasValues = (itemChildren: any) => {
     return false
   }
 
-  return inputs.findIndex(
-    (
-      input: { label: string }
-    ) => {
+  return (
+    inputs.findIndex((input: { label: string }) => {
       return itemChildren[name].valuesOfInputValues[input.label] !== ''
-    }
+    }) !== -1
   )
-  !== -1
 }
 
 const ProductAssemblyOptionItemCustomize: FC<Props> = ({
@@ -136,9 +133,10 @@ const ProductAssemblyOptionItemCustomize: FC<Props> = ({
   }
 
   const handleClick = (e: any) => {
-    if(hasValues(itemChildren)) {
+    if (hasValues(itemChildren)) {
       e.stopPropagation()
     }
+
     setModalOpen(true)
   }
 

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionItemCustomize.tsx
@@ -105,11 +105,13 @@ const hasValues = (itemChildren: any) => {
     return false
   }
 
-  return inputs.findIndex((
+  return inputs.findIndex(
+    (
       input: { label: string }
     ) => {
-    return itemChildren[name].valuesOfInputValues[input.label] !== ''
-  }) 
+      return itemChildren[name].valuesOfInputValues[input.label] !== ''
+    }
+  )
   !== -1
 }
 

--- a/react/package.json
+++ b/react/package.json
@@ -36,13 +36,14 @@
     "typescript": "3.9.7",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector",
-    "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.16.0/public/@types/vtex.flex-layout",
-    "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types",
-    "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.7/public/@types/vtex.product-context",
-    "vtex.product-details": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-details@1.19.10/public/_types/react",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime",
-    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.141.2/public/@types/vtex.store-components",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide"
+    "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.20.1/public/@types/vtex.flex-layout",
+    "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.8.0/public/@types/vtex.native-types",
+    "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context",
+    "vtex.product-customizer": "https://wender--brassbell.myvtex.com/_v/private/typings/linked/v1/vtex.product-customizer@2.11.3+build1666724480/public/@types/vtex.product-customizer",
+    "vtex.product-details": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-details@1.21.0/public/@types/vtex.product-details",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
+    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.163.0/public/@types/vtex.store-components",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.3/public/@types/vtex.styleguide"
   },
   "version": "2.11.3"
 }

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -2,12 +2,21 @@
   "extends": "@vtex/tsconfig",
   "compilerOptions": {
     "jsx": "react",
-    "lib": ["dom"],
+    "lib": [
+      "dom"
+    ],
     "resolveJsonModule": true,
-    "types": ["node", "jest"],
+    "types": [
+      "node",
+      "jest"
+    ],
     "module": "esnext",
     "moduleResolution": "node",
     "target": "es2017"
   },
-  "include": ["./typings/*.d.ts", "./**/*.tsx", "./**/*.ts"]
+  "include": [
+    "./typings/*.d.ts",
+    "./**/*.tsx",
+    "./**/*.ts"
+  ]
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5960,33 +5960,37 @@ vtex-tachyons@^3.2.0:
   version "0.2.6"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector#3219242fa5c2f14023d33c3549c2d8de93c76d1f"
 
-"vtex.flex-layout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.16.0/public/@types/vtex.flex-layout":
-  version "0.16.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.16.0/public/@types/vtex.flex-layout#06e825f6709de8d4d86b74b1940ca28a8fd319c2"
+"vtex.flex-layout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.20.1/public/@types/vtex.flex-layout":
+  version "0.20.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.20.1/public/@types/vtex.flex-layout#dce9424c910091f0ba1f5229ce8ae80c9f7b7765"
 
-"vtex.native-types@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types":
-  version "0.7.5"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types#52d8c0b675fcdf2b6b1ca93f6a99a630519f618f"
+"vtex.native-types@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.8.0/public/@types/vtex.native-types":
+  version "0.8.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.8.0/public/@types/vtex.native-types#4fb38349122295832408d511efefa604a0addc57"
 
-"vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.7/public/@types/vtex.product-context":
-  version "0.9.7"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.7/public/@types/vtex.product-context#4024c589f1ba318e92219a88bf18b4e3774dc85c"
+"vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context":
+  version "0.10.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context#c5e2a97b404004681ee12f4fff7e6b62157786cc"
 
-"vtex.product-details@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-details@1.19.10/public/_types/react":
-  version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-details@1.19.10/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+"vtex.product-customizer@https://wender--brassbell.myvtex.com/_v/private/typings/linked/v1/vtex.product-customizer@2.11.3+build1666724480/public/@types/vtex.product-customizer":
+  version "2.11.3"
+  resolved "https://wender--brassbell.myvtex.com/_v/private/typings/linked/v1/vtex.product-customizer@2.11.3+build1666724480/public/@types/vtex.product-customizer#40c30a2e8c53db13c3fbda4564a910af3b4c1584"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime":
-  version "8.126.11"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime#aceb734766093b56954ec19a074574b4c2c95242"
+"vtex.product-details@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-details@1.21.0/public/@types/vtex.product-details":
+  version "1.21.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-details@1.21.0/public/@types/vtex.product-details#e1c86843e16576ea6b7140546c88783af3f48ac1"
 
-"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.141.2/public/@types/vtex.store-components":
-  version "3.141.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.141.2/public/@types/vtex.store-components#a5e7f7d8f7e6743a36cb6ee27dc064f71900ec67"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime":
+  version "8.132.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide":
-  version "9.135.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide#744a8674d69a56594de969da36b263f94c9de66f"
+"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.163.0/public/@types/vtex.store-components":
+  version "3.163.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.163.0/public/@types/vtex.store-components#c219f8c0eb47bb25b57a2d1d9b47eb9da3ad8643"
+
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.3/public/@types/vtex.styleguide":
+  version "9.146.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.3/public/@types/vtex.styleguide#05558160f29cd8f4aefe419844a4bd66e2b3fdbb"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
#### What problem is this solving?

When a user enters customization and clicks it back to check or make any changes, it unchecks the attachment selection. 

#### How to test it?

[Problem](https://www.awesomescreenshot.com/video/11951834?key=d67e2f1fe93dfd4578bcb0c600b12e89)

[Working Fix](https://wender--brassbell.myvtex.com/7-inch-brass-engravable-wall-bell---antiqued/p)
