### PR TITLE
Fix add to cart behavior when initiallyOpened prop is 'always'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Assembly options will now be correctly added to the cart when `initiallyOpened` prop is set to `always` 
+
 ## [2.11.3] - 2022-07-19
 
 ### Fixed

--- a/react/ProductAssemblyOptions.tsx
+++ b/react/ProductAssemblyOptions.tsx
@@ -8,7 +8,10 @@ interface Props {
   initiallyOpened?: 'always' | 'required'
 }
 
-const ProductAssemblyOptions: FC<Props> = ({ children, initiallyOpened }) => {
+const ProductAssemblyOptions: FC<Props> = ({
+  children,
+  initiallyOpened = 'required',
+}) => {
   const assemblyOptions = useAssemblyOptions()
 
   if (!assemblyOptions) {
@@ -20,6 +23,7 @@ const ProductAssemblyOptions: FC<Props> = ({ children, initiallyOpened }) => {
       {Object.keys(assemblyOptions).map((assemblyOptionId) => (
         <ProductAssemblyGroupContextProvider
           key={assemblyOptionId}
+          initiallyOpened={initiallyOpened}
           assemblyOption={assemblyOptions[assemblyOptionId]}
         >
           <ProductAssemblyOptionsGroup initiallyOpened={initiallyOpened}>

--- a/react/components/ProductAssemblyContext/Group.tsx
+++ b/react/components/ProductAssemblyContext/Group.tsx
@@ -106,7 +106,12 @@ const useRecursiveDispatch = ({
 export const ProductAssemblyGroupContextProvider: FC<ProductAssemblyGroupContextProviderProps> = ({
   assemblyOption,
   children,
+  initiallyOpened = 'required',
 }) => {
+  if (initiallyOpened === 'always') {
+    assemblyOption.optin = true
+  }
+
   const [state, dispatch] = useReducer(reducer, assemblyOption, initState)
 
   const recursiveDispatch = useRecursiveDispatch({
@@ -141,6 +146,7 @@ function getGroupPath(assemblyTreePath?: TreePath[]) {
 
 interface ProductAssemblyGroupContextProviderProps {
   assemblyOption: AssemblyOptionGroupState
+  initiallyOpened?: string
 }
 
 export const useProductAssemblyGroupDispatch = () =>

--- a/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
+++ b/react/components/ProductAssemblyOptions/ProductAssemblyOptionsGroup.tsx
@@ -26,10 +26,7 @@ interface Props {
   initiallyOpened?: 'always' | 'required'
 }
 
-const ProductAssemblyOptionsGroup: FC<Props> = ({
-  children,
-  initiallyOpened = 'required',
-}) => {
+const ProductAssemblyOptionsGroup: FC<Props> = ({ children }) => {
   const intl = useIntl()
   const handles = useCssHandles(CSS_HANDLES)
   const assemblyOptionGroup = useProductAssemblyGroupState() as AssemblyOptionGroupState
@@ -52,7 +49,7 @@ const ProductAssemblyOptionsGroup: FC<Props> = ({
 
   return (
     <Fragment>
-      {assemblyOptionGroup.optin === false && initiallyOpened === 'required' ? (
+      {assemblyOptionGroup.optin === false ? (
         <Button variation="secondary" onClick={changeOptinInput}>
           <IOMessage
             id="store/product-customizer.add-assembly"


### PR DESCRIPTION
#### What problem is this solving?

As described in this issue: https://github.com/vtex-apps/product-customizer/issues/74
When the `initiallyOpened` prop is set to `always`, the component simply doesn't work. Assembly options can be selected on the PDP, but they are ignored when adding to cart. I traced this down to an issue with the `optin` value in the component state. If `optin` is false, the ProductContext is not updated with the user's assembly option selections. And if the `initiallyOpened` prop is set to `always`, there was nothing setting `optin` to `true` (because this was done when the user clicked on the button to open the interface). 

This PR fixes the issue by checking the value of the `initiallyOpened` prop when initializing the component state. If `initiallyOpened` is set to `always`, `optin` will be initialized as `true` instead of `false`.

#### How to test it?

Linked here: https://pdp2--beautycounterqa.myvtex.com/counter-all-bright-c-serum-100000750/p?__bindingAddress=www.beautycounterqa.com/en-us

(The `initiallyOpened` prop is set to `always` in this workspace.)