### PR TITLE
Fix: Delete assembly options from product context if remove button is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Clear assembly options from product context if `Remove` button is clicked
+
 ## [2.12.0] - 2022-12-23
 
 ### Added

--- a/react/modules/useAssemblyOptionsModifications.ts
+++ b/react/modules/useAssemblyOptionsModifications.ts
@@ -16,8 +16,11 @@ export default function useAssemblyOptionsModifications(
       optin,
     } = localState
 
-    const items = Object.values(localItems ?? {}).map(parseItem(type))
-    const isValid = isGroupValid(localState)
+    const items = optin
+      ? Object.values(localItems ?? {}).map(parseItem(type))
+      : []
+
+    const isValid = !optin ? true : isGroupValid(localState)
     const groupInputValues = optin ? valuesOfInputValues : {}
 
     dispatch({


### PR DESCRIPTION
#### What problem is this solving?

Solves a minor bug where if the user configures a product's assembly options (ex. changes the quantity of an item in the assembly options group) and then clicks the REMOVE button, the configured options are still added to cart when the add to cart button is clicked.

This PR fixes the behavior by removing the selections from the product context when the REMOVE button is clicked.

#### How to test it?

Linked here: https://phdro--b2bstoreqa.myvtex.com/axe-package/p

Contact me (`arthur` on Slack) for login credentials.